### PR TITLE
ci: skip claude-review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs (security updates and dependency updates)
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Skip claude-review workflow for Dependabot PRs to avoid authentication errors

## Changes
- Added condition to `.github/workflows/claude-code-review.yml` to skip execution when PR author is `dependabot[bot]`

## Reason
- Dependabot PRs (security updates and dependency updates) don't require manual code review by Claude
- Prevents workflow failures when `CLAUDE_CODE_OAUTH_TOKEN` is not set
- Reduces unnecessary CI runs for automated dependency updates

## Test
- This PR itself will test the change (claude-review should run since it's not from Dependabot)
- Future Dependabot PRs will skip the claude-review step

🤖 Generated with [Claude Code](https://claude.com/claude-code)