### PR TITLE
feat: Add package.json volume mounts for development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,30 @@ docker-compose build frontend
 docker-compose down
 ```
 
+### Development Workflow
+
+#### Managing npm Dependencies
+
+In development mode, `package.json` and `pnpm-lock.yaml` are mounted as volumes, allowing you to add or update dependencies without rebuilding the container:
+
+```bash
+# 1. Edit package.json locally (add/update dependencies)
+vim frontend/package.json
+
+# 2. Install dependencies inside the running container
+docker exec sandbox-frontend pnpm install
+
+# 3. Changes are automatically picked up (no rebuild needed)
+```
+
+**Note**: The container must be running for `docker exec` to work. If you need to rebuild anyway, you can also add dependencies and rebuild:
+
+```bash
+# Alternative: Add dependency and rebuild
+cd frontend && pnpm add <package-name>
+docker-compose build frontend
+```
+
 ## Repository
 
 - **Remote**: https://github.com/nagashima-toru/sandbox-claude-code.git

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -30,6 +30,8 @@ services:
       # Mount source code for hot reload
       - ./frontend/src:/app/src:ro
       - ./frontend/public:/app/public:ro
+      - ./frontend/package.json:/app/package.json:ro
+      - ./frontend/pnpm-lock.yaml:/app/pnpm-lock.yaml:ro
       - ./frontend/next.config.js:/app/next.config.js:ro
       - ./frontend/tailwind.config.ts:/app/tailwind.config.ts:ro
       - ./frontend/postcss.config.js:/app/postcss.config.js:ro


### PR DESCRIPTION
## Summary

Add `package.json` and `pnpm-lock.yaml` to volume mounts in `docker-compose.override.yml` to enable npm dependency management without container rebuilds during development.

## Changes

- Mount `frontend/package.json` and `frontend/pnpm-lock.yaml` as read-only volumes in development mode
- Document the new dependency management workflow in `CLAUDE.md`

## Benefits

Developers can now add or update npm packages without rebuilding the entire frontend container:

```bash
# Edit package.json locally
vim frontend/package.json

# Install dependencies inside running container
docker exec sandbox-frontend pnpm install

# Changes are automatically picked up
```

This significantly improves development workflow by eliminating time-consuming rebuilds when managing dependencies.

## Testing

- Validated `docker-compose config` successfully merges configurations
- Verified volume mounts are correctly applied in merged configuration

## Documentation

Added "Managing npm Dependencies" section to CLAUDE.md with:
- Step-by-step workflow for adding dependencies
- Alternative rebuild approach
- Usage notes and best practices

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)