### PR TITLE
feat: Add Dependabot PR documentation update workflow

### DIFF
--- a/.github/workflows/dependabot-reminder.yml
+++ b/.github/workflows/dependabot-reminder.yml
@@ -1,0 +1,117 @@
+name: Dependabot PR Documentation Reminder
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  check-docs-update:
+    # Only run for Dependabot PRs
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Check if documentation update is needed
+        id: check
+        run: |
+          # Get PR title
+          title="${{ github.event.pull_request.title }}"
+
+          needs_update=false
+
+          # Check for major dependencies that require documentation updates
+          # Backend dependencies
+          if echo "$title" | grep -iE "spring-boot|spring boot|java-|eclipse-temurin|postgres"; then
+            needs_update=true
+          fi
+
+          # Frontend dependencies
+          if echo "$title" | grep -iE "next|react|node|typescript"; then
+            needs_update=true
+          fi
+
+          # Other important dependencies
+          if echo "$title" | grep -iE "maven|pnpm"; then
+            needs_update=true
+          fi
+
+          echo "needs_update=$needs_update" >> $GITHUB_OUTPUT
+          echo "PR title: $title"
+          echo "Needs documentation update: $needs_update"
+
+      - name: Post reminder comment
+        if: steps.check.outputs.needs_update == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prTitle = context.payload.pull_request.title;
+            const prNumber = context.issue.number;
+
+            // Determine which dependencies were updated
+            let dependencyType = "依存関係";
+            if (/spring-boot|spring boot/i.test(prTitle)) {
+              dependencyType = "Spring Boot";
+            } else if (/java-|eclipse-temurin/i.test(prTitle)) {
+              dependencyType = "Java";
+            } else if (/postgres/i.test(prTitle)) {
+              dependencyType = "PostgreSQL";
+            } else if (/next/i.test(prTitle)) {
+              dependencyType = "Next.js";
+            } else if (/react/i.test(prTitle)) {
+              dependencyType = "React";
+            } else if (/node/i.test(prTitle)) {
+              dependencyType = "Node.js";
+            } else if (/typescript/i.test(prTitle)) {
+              dependencyType = "TypeScript";
+            }
+
+            const comment = `## 📝 ドキュメント更新のリマインダー
+
+この依存関係の更新（**${dependencyType}**）は、ドキュメントへの影響がある可能性があります。
+
+### 確認が必要なドキュメント
+
+- \`CLAUDE.md\`
+- \`README.md\`
+- \`backend/README.md\`
+- \`backend/CLAUDE.md\`
+- \`frontend/CLAUDE.md\`
+- \`docs/DEPLOYMENT.md\`
+
+### @claude を使った自動更新
+
+以下のコメントを投稿すると、Claude が自動的にドキュメントを更新します：
+
+\`\`\`markdown
+@claude この PR の依存関係更新に伴い、関連するドキュメントのバージョン情報を更新してください。
+
+対象ファイル:
+- CLAUDE.md
+- README.md
+- backend/README.md
+- backend/CLAUDE.md
+- frontend/CLAUDE.md
+- docs/DEPLOYMENT.md
+
+変更内容を確認し、影響を受けるすべてのバージョン番号を更新してください。
+\`\`\`
+
+### 手動更新
+
+自分で更新する場合は、[Dependabot ドキュメント更新ガイド](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/master/docs/DEPENDABOT_DOCS_UPDATE.md) を参照してください。
+
+---
+
+💡 このリマインダーは自動的に投稿されました。ドキュメント更新が不要な場合は、このコメントを無視してください。`;
+
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+
+            console.log(`Posted reminder comment to PR #${prNumber}`);

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,7 @@ Spring Boot API application with PostgreSQL, MyBatis, and Flyway.
 ## Technology Stack
 
 - **Framework**: Spring Boot 3.4.1
-- **Java Version**: 23
+- **Java Version**: 21
 - **Build Tool**: Maven
 - **Database**: PostgreSQL 16
 - **ORM**: MyBatis
@@ -25,7 +25,7 @@ This project follows **Clean Architecture** principles with the following layers
 
 ## Requirements
 
-- Java 23
+- Java 21
 - Docker (or Colima on macOS)
 
 ## Docker Setup

--- a/docs/DEPENDABOT_DOCS_UPDATE.md
+++ b/docs/DEPENDABOT_DOCS_UPDATE.md
@@ -1,0 +1,278 @@
+# Dependabot PR ドキュメント更新ガイド
+
+## 概要
+
+Dependabot は依存関係を自動的に更新しますが、ドキュメントファイル（CLAUDE.md, README.md など）に記載されているバージョン情報は更新されません。このガイドでは、Dependabot PR に対して @claude を使ってドキュメントを更新する方法を説明します。
+
+## ドキュメント更新が必要な依存関係
+
+以下の依存関係が更新された場合、ドキュメント更新を検討してください。
+
+### Backend（必須）
+
+| 依存関係 | 影響するファイル |
+|---------|-----------------|
+| **Spring Boot** のバージョン変更（メジャー/マイナー） | `CLAUDE.md`, `backend/README.md`, `backend/CLAUDE.md` |
+| **Java** バージョン変更 | `CLAUDE.md`, `backend/README.md`, `backend/CLAUDE.md` |
+| **Docker ベースイメージ**（eclipse-temurin）のバージョン変更 | `backend/Dockerfile`, `backend/README.md` |
+| **PostgreSQL** バージョン変更 | `backend/README.md`, `backend/CLAUDE.md`, `docker-compose.yml` |
+
+### Frontend（必須）
+
+| 依存関係 | 影響するファイル |
+|---------|-----------------|
+| **Next.js** のバージョン変更（メジャー） | `README.md`, `frontend/CLAUDE.md` |
+| **React** のバージョン変更（メジャー） | `README.md`, `frontend/CLAUDE.md` |
+| **Node.js** バージョン変更（Docker イメージ） | `README.md`, `frontend/Dockerfile`, `docs/DEPLOYMENT.md` |
+| **TypeScript** のバージョン変更（メジャー） | `frontend/CLAUDE.md` |
+
+### その他（推奨）
+
+- 主要な UI ライブラリのメジャーバージョン変更（shadcn/ui, Tailwind CSS など）
+- ビルドツールのメジャーバージョン変更（Maven, pnpm など）
+
+## @claude を使ったドキュメント更新手順
+
+### ステップ 1: Dependabot PR を確認
+
+1. Dependabot が作成した PR を開く
+2. PR タイトルと変更内容を確認
+3. 上記の「ドキュメント更新が必要な依存関係」に該当するか判断
+
+### ステップ 2: @claude メンションでドキュメント更新を依頼
+
+該当する場合、PR に以下のようなコメントを投稿します。
+
+#### 基本的なプロンプトテンプレート
+
+```markdown
+@claude この PR の依存関係更新に伴い、関連するドキュメントのバージョン情報を更新してください。
+
+対象ファイル:
+- CLAUDE.md
+- README.md
+- backend/README.md
+- backend/CLAUDE.md
+- frontend/CLAUDE.md
+- docs/DEPLOYMENT.md（該当する場合）
+
+変更内容を確認し、影響を受けるすべてのバージョン番号を更新してください。
+```
+
+#### 具体例 1: Spring Boot 更新時
+
+```markdown
+@claude Spring Boot が 3.4.1 から 3.5.0 に更新されました。以下のドキュメント内の Spring Boot バージョン表記を更新してください：
+- CLAUDE.md
+- backend/README.md
+- backend/CLAUDE.md
+
+また、pom.xml を確認して、実際のバージョン番号と整合性を確認してください。
+```
+
+#### 具体例 2: Java バージョン更新時
+
+```markdown
+@claude Java バージョンが 21 から 23 に変更されました。以下のドキュメント内の Java バージョン表記を更新してください：
+- CLAUDE.md
+- backend/README.md
+- backend/CLAUDE.md
+
+pom.xml の java.version プロパティと整合性を確認してください。
+```
+
+#### 具体例 3: Next.js 更新時
+
+```markdown
+@claude Next.js が 15.1.0 から 16.0.0 に更新されました。以下のドキュメント内の Next.js バージョン表記を更新してください：
+- README.md
+- frontend/CLAUDE.md
+
+package.json の実際のバージョンと整合性を確認してください。
+```
+
+#### 具体例 4: Node.js Docker イメージ更新時
+
+```markdown
+@claude Node.js の Docker ベースイメージが node:20-alpine から node:22-alpine に変更されました。以下のドキュメントを更新してください：
+- README.md
+- frontend/CLAUDE.md
+- docs/DEPLOYMENT.md
+
+frontend/Dockerfile の実際のバージョンと整合性を確認してください。
+```
+
+### ステップ 3: Claude の実行を確認
+
+1. GitHub Actions の「Claude Code」ワークフロー（`.github/workflows/claude.yml`）が自動的にトリガーされます
+2. Claude がコードを分析し、ドキュメントの変更を提案します
+3. Claude が自動的にコミットを追加します
+
+### ステップ 4: 変更内容を確認
+
+1. Claude が追加したコミットを確認
+2. 更新されたドキュメントのバージョン番号が正しいか確認
+3. pom.xml や package.json との整合性を確認
+
+### ステップ 5: マージ
+
+変更内容に問題がなければ、PR をマージします。
+
+## 手動更新が必要な場合
+
+Claude が実行できない場合や、手動で更新したい場合は、以下の手順で更新してください。
+
+### 手順
+
+1. **各ドキュメントファイルを開く**
+2. **該当するバージョン番号を検索**
+   - 例: `3.4.1` で検索
+3. **新しいバージョンに置換**
+   - 例: `3.5.0` に置換
+4. **pom.xml や package.json と整合性を確認**
+   - Backend: `backend/pom.xml` の `<version>` タグと `<java.version>` プロパティ
+   - Frontend: `frontend/package.json` の dependencies
+5. **コミット・プッシュ**
+
+### コマンド例（検索）
+
+```bash
+# Spring Boot のバージョンを検索
+grep -r "Spring Boot 3.4.1" .
+
+# Java のバージョンを検索
+grep -r "Java.*21" backend/
+
+# Next.js のバージョンを検索
+grep -r "Next.js.*15" frontend/
+```
+
+### バージョン情報の真実の情報源
+
+| 技術スタック | 真実の情報源 |
+|-------------|-------------|
+| Spring Boot | `backend/pom.xml` の `<parent><version>` |
+| Java | `backend/pom.xml` の `<java.version>` |
+| Next.js, React, TypeScript | `frontend/package.json` の `dependencies` / `devDependencies` |
+| Node.js (Docker) | `frontend/Dockerfile` の `FROM node:XX-alpine` |
+| PostgreSQL | `docker-compose.yml` の `image: postgres:XX` |
+
+## バージョン情報記載箇所の一覧
+
+### ルートレベル
+
+| ファイル | 記載されているバージョン |
+|---------|----------------------|
+| `CLAUDE.md` | Spring Boot 3.4.1, Java 21 |
+| `README.md` | (プロジェクト概要のみ、詳細なバージョンは各サブディレクトリ) |
+
+### Backend
+
+| ファイル | 記載されているバージョン |
+|---------|----------------------|
+| `backend/README.md` | Spring Boot 3.4.1, Java 21, PostgreSQL 16 |
+| `backend/CLAUDE.md` | Spring Boot 3.4.1, Java 21, PostgreSQL 16 |
+| `backend/pom.xml` | Spring Boot 3.4.1 (parent), Java 21 (properties) |
+| `backend/Dockerfile` | eclipse-temurin ベースイメージバージョン |
+
+### Frontend
+
+| ファイル | 記載されているバージョン |
+|---------|----------------------|
+| `README.md` | Next.js 15+, TypeScript, Node.js 20+ |
+| `frontend/CLAUDE.md` | Next.js 15+ (App Router), TypeScript |
+| `frontend/package.json` | Next.js ^15.1.0, React ^19.0.0, TypeScript ^5.7.3 |
+| `frontend/Dockerfile` | node:20-alpine |
+
+### Infrastructure
+
+| ファイル | 記載されているバージョン |
+|---------|----------------------|
+| `docker-compose.yml` | PostgreSQL 16, Node.js 20-alpine |
+| `docs/DEPLOYMENT.md` | Node.js 20-alpine |
+
+## 整合性チェックスクリプト
+
+以下のスクリプトを使って、ドキュメントとソースコードのバージョン情報の整合性を確認できます。
+
+```bash
+#!/bin/bash
+# version-check.sh
+
+echo "=== Version Information Check ==="
+echo ""
+
+echo "--- Backend ---"
+echo "Spring Boot (pom.xml):"
+grep "<parent>" -A 3 backend/pom.xml | grep "<version>"
+
+echo "Java (pom.xml):"
+grep "<java.version>" backend/pom.xml
+
+echo "Spring Boot (CLAUDE.md):"
+grep "Spring Boot" CLAUDE.md backend/README.md backend/CLAUDE.md
+
+echo "Java (Documentation):"
+grep -E "Java.*21|Java.*23" CLAUDE.md backend/README.md backend/CLAUDE.md
+
+echo ""
+echo "--- Frontend ---"
+echo "Next.js (package.json):"
+grep '"next"' frontend/package.json
+
+echo "Next.js (Documentation):"
+grep -i "next.js" README.md frontend/CLAUDE.md
+
+echo "Node.js (Dockerfile):"
+grep "FROM node:" frontend/Dockerfile
+
+echo ""
+echo "--- Database ---"
+echo "PostgreSQL (docker-compose.yml):"
+grep "image: postgres:" docker-compose.yml
+
+echo "PostgreSQL (Documentation):"
+grep -i "postgresql" backend/README.md backend/CLAUDE.md
+```
+
+このスクリプトを実行することで、各ドキュメントとソースコードのバージョン情報を一覧表示し、整合性を目視で確認できます。
+
+## トラブルシューティング
+
+### Claude が応答しない場合
+
+1. **GitHub Actions のログを確認**
+   - リポジトリの「Actions」タブを開く
+   - 「Claude Code」ワークフローの実行ログを確認
+   - エラーメッセージがある場合は内容を確認
+
+2. **再度メンションを試す**
+   - 別のコメントで再度 @claude メンションを投稿
+   - より具体的なファイル名とバージョン番号を指定
+
+3. **手動更新に切り替え**
+   - 上記の「手動更新が必要な場合」のセクションを参照
+
+### バージョン番号が一致しない場合
+
+1. **真実の情報源を確認**
+   - Backend: `backend/pom.xml`
+   - Frontend: `frontend/package.json`
+
+2. **ドキュメントを手動で修正**
+   - 該当するドキュメントファイルを開いて修正
+
+3. **整合性チェックスクリプトを実行**
+   - すべてのバージョン情報が一致していることを確認
+
+## 参考リンク
+
+- [Dependabot 公式ドキュメント](https://docs.github.com/ja/code-security/dependabot)
+- [GitHub Actions ワークフロー](../.github/workflows/claude.yml)
+- [プロジェクトの CLAUDE.md](../CLAUDE.md)
+- [Backend の CLAUDE.md](../backend/CLAUDE.md)
+- [Frontend の CLAUDE.md](../frontend/CLAUDE.md)
+
+## まとめ
+
+Dependabot PR でドキュメントのバージョン情報を更新するには、@claude メンションを使うのが最も簡単で効率的です。必要に応じて手動更新も可能です。定期的に整合性チェックスクリプトを実行することで、ドキュメントとソースコードの一貫性を保つことができます。


### PR DESCRIPTION
## 概要

Dependabot による依存関係更新時に、ドキュメントのバージョン情報を自動的に更新するためのワークフローとガイドラインを追加しました。

## 背景

Dependabot は依存関係を自動更新しますが、ドキュメントファイル（CLAUDE.md, README.md など）のバージョン情報は更新されません。これにより、ドキュメントとソースコードの間でバージョン情報の不整合が発生していました（例: backend/README.md に Java 23 と記載されていたが、pom.xml には Java 21）。

## 変更内容

### 1. 現在の不整合を修正

- **backend/README.md**: Java バージョンを 23 → 21 に修正（pom.xml と整合）

### 2. Dependabot ドキュメント更新ガイドの作成

- **docs/DEPENDABOT_DOCS_UPDATE.md**: 包括的なドキュメント更新ガイド
  - ドキュメント更新が必要な依存関係のリスト
  - @claude を使った自動更新の手順
  - 様々なシナリオに対応したプロンプトテンプレート
  - 手動更新の手順
  - バージョン情報の参照テーブル
  - トラブルシューティング

### 3. 自動リマインダーワークフローの追加

- **.github/workflows/dependabot-reminder.yml**: Dependabot PR 用の自動リマインダー
  - Dependabot PR 作成時に自動実行
  - 主要な依存関係（Spring Boot, Java, Next.js, React, Node.js など）の更新を検出
  - ドキュメント更新が必要な場合にリマインダーコメントを投稿
  - @claude を使った更新手順とプロンプト例を提供

## 動作確認

### バージョン整合性チェック

すべてのバージョン情報が一致していることを確認：

- ✅ **Spring Boot**: 3.4.1（pom.xml と documentation が一致）
- ✅ **Java**: 21（pom.xml と documentation が一致）
- ✅ **Next.js**: 15+（package.json と documentation が一致）
- ✅ **React**: 19.0.0（package.json と documentation が一致）
- ✅ **PostgreSQL**: 16（docker-compose.yml と documentation が一致）

### 既存ワークフローの確認

- ✅ **claude.yml**: @claude メンションが Dependabot PR でも動作
- ✅ **claude-code-review.yml**: Dependabot PR を正しくスキップ

## 使い方

次回、Dependabot が主要な依存関係を更新したときに：

1. **自動リマインダー**が PR にコメントとして投稿される
2. **@claude をメンション**してドキュメント更新を依頼
   ```markdown
   @claude この PR の依存関係更新に伴い、関連するドキュメントのバージョン情報を更新してください。
   ```
3. **Claude が自動的に**すべての関連ドキュメントを更新
4. **変更を確認**してマージ

## テスト計画

- [ ] 次回の Dependabot PR でリマインダーが投稿されることを確認
- [ ] @claude メンションでドキュメントが正しく更新されることを確認
- [ ] 整合性チェックスクリプトを定期的に実行

## 関連 Issue

このPRは、Dependabot PR でのドキュメント更新問題を解決するためのものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)