### PR TITLE
feat: Mount .env.local for development environment customization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,54 @@ docker-compose -f docker-compose.yml up --build
 docker-compose down
 ```
 
+#### Customizing Environment Variables
+
+**Using .env.local (Recommended)**:
+
+Development mode automatically mounts `frontend/.env.local` if it exists, allowing you to customize environment variables without modifying docker-compose files.
+
+```bash
+# 1. Copy example file
+cp frontend/.env.local.example frontend/.env.local
+
+# 2. Edit with your custom values
+vim frontend/.env.local
+
+# 3. Restart container (for runtime variables)
+docker-compose restart frontend
+
+# 4. For NEXT_PUBLIC_* variables (build-time), rebuild:
+docker-compose build frontend && docker-compose up
+```
+
+**Environment Variable Precedence** (highest to lowest):
+
+1. docker-compose.override.yml (highest)
+2. .env.local (medium)
+3. docker-compose.yml (lowest)
+
+**Important Notes**:
+
+- Variables in docker-compose.override.yml override .env.local
+- To use .env.local for a variable, remove it from docker-compose.override.yml
+- `NEXT_PUBLIC_*` variables are bundled at build time (require rebuild)
+- Other variables take effect on container restart
+- .env.local is gitignored (safe for secrets in local development)
+
+**Example**:
+
+If you want to test a different API URL:
+
+```bash
+# Option 1: Remove NEXT_PUBLIC_API_URL from docker-compose.override.yml
+# Then set it in .env.local
+echo "NEXT_PUBLIC_API_URL=http://different-api:8080" >> frontend/.env.local
+docker-compose build frontend && docker-compose up
+
+# Option 2: Keep it in docker-compose.override.yml for team-wide default
+# Individual developers can override by editing docker-compose.override.yml locally (not recommended)
+```
+
 ### Troubleshooting
 
 #### Hot Reload Not Working

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -36,4 +36,8 @@ services:
       - ./frontend/tailwind.config.ts:/app/tailwind.config.ts:ro
       - ./frontend/postcss.config.js:/app/postcss.config.js:ro
       - ./frontend/tsconfig.json:/app/tsconfig.json:ro
+      # Mount .env.local if exists (optional, allows customization without modifying compose files)
+      # Note: Environment variables defined above have higher precedence than .env.local
+      # Container restart required for env var changes (rebuild needed for NEXT_PUBLIC_* vars)
+      - ./frontend/.env.local:/app/.env.local:ro
     command: ["pnpm", "dev"]

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,3 +1,27 @@
+# .env.local.example
+# Copy this file to .env.local to customize environment variables for local development
+# .env.local is gitignored and will not be committed to version control
+
+# =============================================================================
+# IMPORTANT: Environment Variable Precedence in Docker
+# =============================================================================
+# When using docker-compose with .env.local mounting:
+#
+# 1. Environment variables defined in docker-compose.override.yml have HIGHEST precedence
+# 2. Variables in .env.local (this file) have LOWER precedence
+# 3. Variables in docker-compose.yml have LOWEST precedence
+#
+# This means:
+# - If a variable is set in docker-compose.override.yml, it will override .env.local
+# - Use .env.local for variables NOT defined in docker-compose files
+# - Or, remove the variable from docker-compose.override.yml to allow .env.local to take effect
+#
+# Build-time vs Runtime:
+# - NEXT_PUBLIC_* variables are build-time (bundled into browser JavaScript)
+# - Changing NEXT_PUBLIC_* requires container rebuild: docker-compose build frontend
+# - Other variables can be changed with just container restart
+# =============================================================================
+
 # API Base URL
 # For development: use http://localhost:8080 (direct backend access)
 # For production with nginx: use empty string "" (generated API code already has /api prefix)
@@ -5,4 +29,15 @@
 NEXT_PUBLIC_API_URL=http://localhost:8080
 
 # Environment
+# Note: NODE_ENV is overridden by docker-compose.override.yml (set to "development")
+# Remove from docker-compose.override.yml if you want to control it here
 NODE_ENV=development
+
+# =============================================================================
+# How to Use This File
+# =============================================================================
+# 1. Copy this file: cp .env.local.example .env.local
+# 2. Edit .env.local with your custom values
+# 3. Restart container: docker-compose restart frontend
+# 4. For NEXT_PUBLIC_* changes: docker-compose build frontend && docker-compose up
+# =============================================================================


### PR DESCRIPTION
## Summary

- Mount `frontend/.env.local` in development mode for easy environment variable customization
- Update `.env.local.example` with detailed precedence documentation
- Add "Customizing Environment Variables" section to `CLAUDE.md`

## Changes

### 1. docker-compose.override.yml
- Added volume mount for `frontend/.env.local` (read-only)
- Allows developers to customize env vars without modifying compose files
- Includes clear comments about precedence and rebuild requirements

### 2. frontend/.env.local.example
- Added comprehensive documentation about env var precedence in Docker
- Explained build-time vs runtime variables
- Provided step-by-step usage instructions
- Clarified when container restart vs rebuild is needed

### 3. CLAUDE.md
- Added new section "Customizing Environment Variables"
- Documented the recommended workflow using `.env.local`
- Explained precedence rules (compose.override.yml > .env.local > compose.yml)
- Provided practical examples for testing different API URLs

## Benefits

- **No compose file modifications**: Developers can customize env vars without editing version-controlled files
- **Secrets safe**: `.env.local` is gitignored, safe for local development secrets
- **Clear precedence**: Well-documented rules prevent confusion
- **Easy testing**: Quick way to test different configurations

## Environment Variable Precedence

1. `docker-compose.override.yml` (highest)
2. `.env.local` (medium)
3. `docker-compose.yml` (lowest)

## Usage Example

```bash
# Copy example file
cp frontend/.env.local.example frontend/.env.local

# Edit with custom values
vim frontend/.env.local

# Restart for runtime variables
docker-compose restart frontend

# Rebuild for NEXT_PUBLIC_* variables
docker-compose build frontend && docker-compose up
```

## Testing

- Verified docker-compose config merges .env.local mount correctly
- Confirmed .env.local is already in .gitignore
- Pre-commit hooks passed

## Notes

- `.env.local` file must exist for mount to work (Docker creates empty file if missing)
- Variables in `docker-compose.override.yml` override `.env.local` values
- `NEXT_PUBLIC_*` variables require rebuild as they are bundled at build time
- Other variables take effect on container restart

Resolves #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)