### PR TITLE
[Spec] 認証・認可機能の仕様定義 #88

### DIFF
--- a/specs/acceptance/auth/authorization.feature
+++ b/specs/acceptance/auth/authorization.feature
@@ -1,0 +1,127 @@
+# language: ja
+@auth @authorization @api
+Feature: 認可機能
+
+  ロールベースのアクセス制御（RBAC）
+
+  Background:
+    Given 以下のユーザーが存在する:
+      | username | password  | role   | enabled |
+      | admin    | admin123  | ADMIN  | true    |
+      | viewer   | viewer123 | VIEWER | true    |
+    And 以下のメッセージが存在する:
+      | code    | content   |
+      | MSG_001 | Message 1 |
+
+  # ADMIN ロールの権限テスト
+  @positive @admin
+  Scenario: ADMIN ユーザーはメッセージ一覧を取得できる
+    Given ユーザー "admin" でログインする
+    When 取得したアクセストークンで GET /api/messages を呼び出す
+    Then ステータスコード 200 が返される
+
+  @positive @admin
+  Scenario: ADMIN ユーザーはメッセージ詳細を取得できる
+    Given ユーザー "admin" でログインする
+    When 取得したアクセストークンで GET /api/messages/1 を呼び出す
+    Then ステータスコード 200 が返される
+
+  @positive @admin
+  Scenario: ADMIN ユーザーはメッセージを作成できる
+    Given ユーザー "admin" でログインする
+    And 以下のメッセージ情報を準備する:
+      | code    | content       |
+      | MSG_002 | New Message 2 |
+    When 取得したアクセストークンで POST /api/messages を呼び出す
+    Then ステータスコード 201 が返される
+
+  @positive @admin
+  Scenario: ADMIN ユーザーはメッセージを更新できる
+    Given ユーザー "admin" でログインする
+    And 以下のメッセージ情報を準備する:
+      | code    | content           |
+      | MSG_001 | Updated Message 1 |
+    When 取得したアクセストークンで PUT /api/messages/1 を呼び出す
+    Then ステータスコード 200 が返される
+
+  @positive @admin
+  Scenario: ADMIN ユーザーはメッセージを削除できる
+    Given ユーザー "admin" でログインする
+    When 取得したアクセストークンで DELETE /api/messages/1 を呼び出す
+    Then ステータスコード 204 が返される
+
+  # VIEWER ロールの権限テスト
+  @positive @viewer
+  Scenario: VIEWER ユーザーはメッセージ一覧を取得できる
+    Given ユーザー "viewer" でログインする
+    When 取得したアクセストークンで GET /api/messages を呼び出す
+    Then ステータスコード 200 が返される
+
+  @positive @viewer
+  Scenario: VIEWER ユーザーはメッセージ詳細を取得できる
+    Given ユーザー "viewer" でログインする
+    When 取得したアクセストークンで GET /api/messages/1 を呼び出す
+    Then ステータスコード 200 が返される
+
+  @negative @viewer
+  Scenario: VIEWER ユーザーはメッセージを作成できない
+    Given ユーザー "viewer" でログインする
+    And 以下のメッセージ情報を準備する:
+      | code    | content       |
+      | MSG_002 | New Message 2 |
+    When 取得したアクセストークンで POST /api/messages を呼び出す
+    Then ステータスコード 403 が返される
+    And エラーレスポンスがRFC 7807形式である
+    And エラーレスポンスに以下が含まれる:
+      | フィールド | 値                                              |
+      | status    | 403                                             |
+      | title     | Authorization Error                             |
+      | detail    | Insufficient permissions to access this resource |
+
+  @negative @viewer
+  Scenario: VIEWER ユーザーはメッセージを更新できない
+    Given ユーザー "viewer" でログインする
+    And 以下のメッセージ情報を準備する:
+      | code    | content           |
+      | MSG_001 | Updated Message 1 |
+    When 取得したアクセストークンで PUT /api/messages/1 を呼び出す
+    Then ステータスコード 403 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+  @negative @viewer
+  Scenario: VIEWER ユーザーはメッセージを削除できない
+    Given ユーザー "viewer" でログインする
+    When 取得したアクセストークンで DELETE /api/messages/1 を呼び出す
+    Then ステータスコード 403 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+  # 認証なしのアクセステスト
+  @negative @unauthorized
+  Scenario Outline: 認証なしで保護されたエンドポイントにアクセスできない
+    Given 認証トークンなしでリクエストする
+    When <method> <endpoint> を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+    Examples:
+      | method | endpoint          |
+      | GET    | /api/messages     |
+      | POST   | /api/messages     |
+      | GET    | /api/messages/1   |
+      | PUT    | /api/messages/1   |
+      | DELETE | /api/messages/1   |
+
+  # 無効なトークンでのアクセステスト
+  @negative @unauthorized
+  Scenario: 無効なトークンで保護されたエンドポイントにアクセスできない
+    Given 無効なトークンでリクエストする
+    When GET /api/messages を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+  @negative @unauthorized
+  Scenario: 期限切れトークンで保護されたエンドポイントにアクセスできない
+    Given 期限切れのアクセストークンでリクエストする
+    When GET /api/messages を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である

--- a/specs/acceptance/auth/login.feature
+++ b/specs/acceptance/auth/login.feature
@@ -1,0 +1,97 @@
+# language: ja
+@auth @login @api
+Feature: ログイン機能
+
+  JWTベースの認証機能
+
+  Background:
+    Given 以下のユーザーが存在する:
+      | username | password  | role   | enabled |
+      | admin    | admin123  | ADMIN  | true    |
+      | viewer   | viewer123 | VIEWER | true    |
+      | disabled | test123   | VIEWER | false   |
+
+  @positive
+  Scenario: 正しい認証情報でログインする（ADMIN）
+    Given 以下のログイン情報を準備する:
+      | username | password |
+      | admin    | admin123 |
+    When POST /api/auth/login を呼び出す
+    Then ステータスコード 200 が返される
+    And レスポンスボディに以下が含まれる:
+      | フィールド | 値     |
+      | tokenType | Bearer |
+    And レスポンスボディに accessToken が含まれる
+    And レスポンスボディに refreshToken が含まれる
+    And レスポンスボディに expiresIn が含まれる
+    And accessToken が有効なJWTトークンである
+    And refreshToken が有効なJWTトークンである
+
+  @positive
+  Scenario: 正しい認証情報でログインする（VIEWER）
+    Given 以下のログイン情報を準備する:
+      | username | password  |
+      | viewer   | viewer123 |
+    When POST /api/auth/login を呼び出す
+    Then ステータスコード 200 が返される
+    And レスポンスボディに accessToken が含まれる
+    And レスポンスボディに refreshToken が含まれる
+
+  @negative
+  Scenario: 誤ったパスワードでログインを試みる
+    Given 以下のログイン情報を準備する:
+      | username | password    |
+      | admin    | wrongpasswd |
+    When POST /api/auth/login を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+    And エラーレスポンスに以下が含まれる:
+      | フィールド | 値                       |
+      | status    | 401                      |
+      | title     | Authentication Error     |
+      | detail    | Invalid credentials or token |
+
+  @negative
+  Scenario: 存在しないユーザーでログインを試みる
+    Given 以下のログイン情報を準備する:
+      | username    | password |
+      | nonexistent | test     |
+    When POST /api/auth/login を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+    And エラーレスポンスに以下が含まれる:
+      | フィールド | 値                       |
+      | status    | 401                      |
+      | title     | Authentication Error     |
+      | detail    | Invalid credentials or token |
+
+  @negative
+  Scenario: 無効化されたユーザーでログインを試みる
+    Given 以下のログイン情報を準備する:
+      | username | password |
+      | disabled | test123  |
+    When POST /api/auth/login を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+  @negative @validation
+  Scenario Outline: バリデーションエラー - 必須フィールドの欠如
+    Given 以下のログイン情報を準備する:
+      | username   | password   |
+      | <username> | <password> |
+    When POST /api/auth/login を呼び出す
+    Then ステータスコード 400 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+    Examples:
+      | username | password |
+      |          | admin123 |
+      | admin    |          |
+
+  @positive @security
+  Scenario: ログイン成功後、トークンで保護されたリソースにアクセスできる
+    Given 以下のログイン情報でログインする:
+      | username | password |
+      | admin    | admin123 |
+    When 取得したアクセストークンで GET /api/messages を呼び出す
+    Then ステータスコード 200 が返される

--- a/specs/acceptance/auth/logout.feature
+++ b/specs/acceptance/auth/logout.feature
@@ -1,0 +1,55 @@
+# language: ja
+@auth @logout @api
+Feature: ログアウト機能
+
+  リフレッシュトークンを無効化してログアウトする
+
+  Background:
+    Given 以下のユーザーが存在する:
+      | username | password | role  | enabled |
+      | admin    | admin123 | ADMIN | true    |
+
+  @positive
+  Scenario: 正常にログアウトする
+    Given ユーザー "admin" でログインする
+    When 取得したアクセストークンで POST /api/auth/logout を呼び出す
+    Then ステータスコード 204 が返される
+
+  @positive
+  Scenario: ログアウト後、リフレッシュトークンが無効化されている
+    Given ユーザー "admin" でログインする
+    And ログインレスポンスからリフレッシュトークンを保存する
+    When 取得したアクセストークンで POST /api/auth/logout を呼び出す
+    Then ステータスコード 204 が返される
+    When 保存したリフレッシュトークンで POST /api/auth/refresh を試みる
+    Then ステータスコード 401 が返される
+
+  @positive
+  Scenario: ログアウト後、アクセストークンは有効期限まで使用可能
+    Given ユーザー "admin" でログインする
+    And ログインレスポンスからアクセストークンを保存する
+    When 保存したアクセストークンで POST /api/auth/logout を呼び出す
+    Then ステータスコード 204 が返される
+    When 保存したアクセストークンで GET /api/messages を呼び出す
+    Then ステータスコード 200 が返される
+
+  @negative
+  Scenario: 認証なしでログアウトを試みる
+    Given 認証トークンなしでリクエストする
+    When POST /api/auth/logout を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+  @negative
+  Scenario: 無効なトークンでログアウトを試みる
+    Given 無効なトークンでリクエストする
+    When POST /api/auth/logout を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+  @negative
+  Scenario: 期限切れトークンでログアウトを試みる
+    Given 期限切れのアクセストークンでリクエストする
+    When POST /api/auth/logout を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である

--- a/specs/acceptance/auth/refresh-token.feature
+++ b/specs/acceptance/auth/refresh-token.feature
@@ -1,0 +1,66 @@
+# language: ja
+@auth @refresh @api
+Feature: トークンリフレッシュ機能
+
+  リフレッシュトークンを使用してアクセストークンを更新する
+
+  Background:
+    Given 以下のユーザーが存在する:
+      | username | password | role  | enabled |
+      | admin    | admin123 | ADMIN | true    |
+
+  @positive
+  Scenario: 有効なリフレッシュトークンで新しいアクセストークンを取得する
+    Given ユーザー "admin" でログインする
+    And ログインレスポンスからリフレッシュトークンを取得する
+    When 以下のリフレッシュ情報で POST /api/auth/refresh を呼び出す:
+      | refreshToken | <取得したリフレッシュトークン> |
+    Then ステータスコード 200 が返される
+    And レスポンスボディに以下が含まれる:
+      | フィールド | 値     |
+      | tokenType | Bearer |
+    And レスポンスボディに accessToken が含まれる
+    And レスポンスボディに refreshToken が含まれる
+    And 新しいアクセストークンが有効なJWTトークンである
+
+  @positive
+  Scenario: 新しいアクセストークンで保護されたリソースにアクセスできる
+    Given ユーザー "admin" でログインする
+    And リフレッシュトークンで新しいアクセストークンを取得する
+    When 新しいアクセストークンで GET /api/messages を呼び出す
+    Then ステータスコード 200 が返される
+
+  @negative
+  Scenario: 無効なリフレッシュトークンでトークンリフレッシュを試みる
+    Given 以下のリフレッシュ情報を準備する:
+      | refreshToken                |
+      | invalid.refresh.token.value |
+    When POST /api/auth/refresh を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+    And エラーレスポンスに以下が含まれる:
+      | フィールド | 値                       |
+      | status    | 401                      |
+      | title     | Authentication Error     |
+
+  @negative
+  Scenario: 期限切れのリフレッシュトークンでトークンリフレッシュを試みる
+    Given 期限切れのリフレッシュトークンを準備する
+    When 期限切れのリフレッシュトークンで POST /api/auth/refresh を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+  @negative
+  Scenario: 無効化されたリフレッシュトークンで トークンリフレッシュを試みる
+    Given ユーザー "admin" でログインする
+    And ログアウトしてリフレッシュトークンを無効化する
+    When 無効化されたリフレッシュトークンで POST /api/auth/refresh を呼び出す
+    Then ステータスコード 401 が返される
+    And エラーレスポンスがRFC 7807形式である
+
+  @negative @validation
+  Scenario: リフレッシュトークンなしでリクエストする
+    Given リフレッシュトークンなしでリクエストを準備する
+    When POST /api/auth/refresh を呼び出す
+    Then ステータスコード 400 が返される
+    And エラーレスポンスがRFC 7807形式である

--- a/specs/openapi/openapi.yaml
+++ b/specs/openapi/openapi.yaml
@@ -17,10 +17,84 @@ servers:
     description: Docker production server
 
 tags:
+  - name: Auth
+    description: 認証・認可API
   - name: Message
     description: メッセージ管理API
 
 paths:
+  /api/auth/login:
+    post:
+      tags:
+        - Auth
+      summary: ログイン
+      description: |
+        ユーザー名とパスワードでログインし、JWTトークンを取得します。
+
+        **受け入れ条件:** specs/acceptance/auth/login.feature
+      operationId: login
+      security: []  # 認証不要
+      requestBody:
+        description: ログイン情報
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: ログイン成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/auth/refresh:
+    post:
+      tags:
+        - Auth
+      summary: トークンリフレッシュ
+      description: |
+        リフレッシュトークンを使用して新しいアクセストークンを取得します。
+
+        **受け入れ条件:** specs/acceptance/auth/refresh-token.feature
+      operationId: refreshToken
+      security: []  # トークン検証のみ
+      requestBody:
+        description: リフレッシュトークン
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshRequest'
+      responses:
+        '200':
+          description: リフレッシュ成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/auth/logout:
+    post:
+      tags:
+        - Auth
+      summary: ログアウト
+      description: |
+        リフレッシュトークンを無効化してログアウトします。
+
+        **受け入れ条件:** specs/acceptance/auth/logout.feature
+      operationId: logout
+      responses:
+        '204':
+          description: ログアウト成功
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /api/messages:
     get:
       tags:
@@ -95,6 +169,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '409':
           $ref: '#/components/responses/Conflict'
 
@@ -158,6 +234,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
@@ -182,6 +260,8 @@ paths:
           description: 削除成功
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -252,6 +332,64 @@ components:
           type: string
           description: エラーメッセージ
           example: 'コードは必須です'
+
+    # 認証関連スキーマ
+    LoginRequest:
+      type: object
+      description: ログインリクエスト
+      required:
+        - username
+        - password
+      properties:
+        username:
+          type: string
+          description: ユーザー名
+          minLength: 1
+          maxLength: 50
+          example: 'admin'
+        password:
+          type: string
+          description: パスワード
+          minLength: 1
+          example: 'admin123'
+
+    LoginResponse:
+      type: object
+      description: ログインレスポンス
+      required:
+        - accessToken
+        - refreshToken
+        - tokenType
+        - expiresIn
+      properties:
+        accessToken:
+          type: string
+          description: アクセストークン（JWT）
+          example: 'eyJhbGciOiJIUzI1NiIs...'
+        refreshToken:
+          type: string
+          description: リフレッシュトークン（JWT）
+          example: 'eyJhbGciOiJIUzI1NiIs...'
+        tokenType:
+          type: string
+          description: トークンタイプ
+          example: 'Bearer'
+        expiresIn:
+          type: integer
+          format: int32
+          description: アクセストークンの有効期限（秒）
+          example: 3600
+
+    RefreshRequest:
+      type: object
+      description: トークンリフレッシュリクエスト
+      required:
+        - refreshToken
+      properties:
+        refreshToken:
+          type: string
+          description: リフレッシュトークン
+          example: 'eyJhbGciOiJIUzI1NiIs...'
 
     # メッセージ関連スキーマ
     MessageRequest:
@@ -367,6 +505,13 @@ components:
           schema:
             $ref: '#/components/schemas/ProblemDetail'
 
+    Forbidden:
+      description: 認可エラー（権限不足）
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetail'
+
     NotFound:
       description: リソースが見つかりません
       content:
@@ -396,6 +541,6 @@ components:
       description: JWT認証トークン
 
 # デフォルトでは全エンドポイントで認証が必要
-# （認証実装後に有効化）
-# security:
-#   - BearerAuth: []
+# （個別のエンドポイントで security: [] を指定すると認証不要にできる）
+security:
+  - BearerAuth: []


### PR DESCRIPTION
## 対象Story

Story: #88

## 変更内容

### OpenAPI仕様の変更

- [x] 新規エンドポイント追加
- [ ] 既存エンドポイント変更
- [x] スキーマ追加/変更
- [x] レスポンス定義追加/変更

**変更ファイル：**
- `specs/openapi/openapi.yaml`

**変更概要：**

**新規エンドポイント：**
- `POST /api/auth/login` - ユーザー名・パスワードでログインし、JWTトークンを取得
- `POST /api/auth/refresh` - リフレッシュトークンで新しいアクセストークンを取得
- `POST /api/auth/logout` - リフレッシュトークンを無効化してログアウト

**新規スキーマ：**
- `LoginRequest` - ログインリクエスト（username, password）
- `LoginResponse` - ログインレスポンス（accessToken, refreshToken, tokenType, expiresIn）
- `RefreshRequest` - トークンリフレッシュリクエスト（refreshToken）

**セキュリティ設定：**
- グローバルセキュリティ設定（BearerAuth）を有効化
- 認証不要エンドポイント（`/api/auth/login`, `/api/auth/refresh`）には `security: []` を明示

**レスポンス追加：**
- `Forbidden (403)` レスポンスを追加（認可エラー用）
- メッセージの POST/PUT/DELETE エンドポイントに 403 レスポンスを追加（VIEWER ロールの権限不足エラー用）

### 受け入れ条件ファイル

- [x] 新規 .feature ファイル作成
- [ ] 既存 .feature ファイル更新

**ファイル：**
- `specs/acceptance/auth/login.feature`
- `specs/acceptance/auth/refresh-token.feature`
- `specs/acceptance/auth/logout.feature`
- `specs/acceptance/auth/authorization.feature`

**シナリオ数：**
- 正常系: 13件
- 異常系: 22件

**主なシナリオ：**

**login.feature:**
- 正常系：ADMIN/VIEWER ロールでのログイン成功
- 異常系：誤ったパスワード、存在しないユーザー、無効化されたユーザー、バリデーションエラー

**refresh-token.feature:**
- 正常系：有効なリフレッシュトークンでアクセストークン更新
- 異常系：無効なトークン、期限切れトークン、無効化されたトークン

**logout.feature:**
- 正常系：ログアウト成功、リフレッシュトークン無効化の確認
- 異常系：認証なし、無効なトークン、期限切れトークン

**authorization.feature:**
- ADMIN ロール：全操作（GET/POST/PUT/DELETE）の成功確認
- VIEWER ロール：読取操作（GET）のみ成功、書込操作（POST/PUT/DELETE）は 403 エラー
- 認証なし：全エンドポイントで 401 エラー

## 仕様の完全性

- [x] すべてのエンドポイントに受け入れ条件が定義されている
- [x] 正常系と異常系の両方がカバーされている
- [x] エラーレスポンスが RFC 7807 形式で定義されている
- [x] Gherkin構文が正しい（CI で自動検証）
- [x] OpenAPI構文が正しい（CI で自動検証）

## Breaking Changes

- [x] 破壊的変更あり
- [ ] 破壊的変更なし

**詳細：**

既存のすべてのメッセージAPI（`/api/messages`）が認証必須になります：
- 現在：認証なしでアクセス可能
- 変更後：有効なJWTトークンが必須（401 Unauthorized）

**影響範囲：**
- フロントエンドのAPI呼び出しに `Authorization: Bearer <token>` ヘッダーの追加が必要
- 既存のテストコードの修正が必要（認証トークンの取得処理追加）
- APIクライアント（Orval生成コード）の更新が必要

**移行計画：**
1. 仕様PRマージ後、フロントエンド・バックエンドで並行して実装
2. Story 6（フロントエンド）と Story 3（認証エンドポイント）の実装完了を待って、Story 7（結合テスト）で動作確認
3. すべてのStoryのマージ後、master ブランチで統合

## レビュー観点

- [x] 受け入れ条件が明確で検証可能か
  - すべてのシナリオが Given-When-Then 形式で明確に記述されています
  - テスト実装に必要な情報（ユーザー、ロール、期待レスポンス）が含まれています
  
- [x] API設計がRESTfulか
  - `/api/auth/*` で認証関連エンドポイントを統一
  - 適切なHTTPメソッド（POST）とステータスコード（200, 204, 401, 403）を使用
  - JWT Bearer 認証の業界標準に準拠
  
- [x] エラーハンドリングが適切か
  - すべてのエラーレスポンスが RFC 7807 形式
  - 認証エラー（401）と認可エラー（403）を明確に区別
  - ユーザー列挙攻撃対策（ログイン失敗時の詳細を非公開）
  
- [x] セキュリティ上の懸念はないか
  - パスワードはリクエストボディのみ（URLパラメータ使用なし）
  - トークンは Bearer 認証で送信（HTTP ヘッダー使用）
  - リフレッシュトークン無効化機能あり（ログアウト時）
  - 無効化されたユーザーのログイン拒否

## 備考

**次のステップ：**
1. この仕様PRがマージされたら、Issue #88 に `spec-approved` ラベルを付与
2. `.epic/20260203-auth/` の実装計画に基づいて、各 Story の実装を開始
3. Story の実装順序：
   - Story 1: ユーザー管理（DB、エンティティ、リポジトリ）
   - Story 2: JWT トークン生成・検証
   - Story 3: 認証エンドポイント
   - Story 4: 認可（Spring Security 設定、ロールベースアクセス制御）
   - Story 5: OpenAPI 生成コード更新
   - Story 6: フロントエンド認証対応
   - Story 7: 結合テスト

**関連ドキュメント：**
- [requirements.md](.epic/20260203-auth/requirements.md) - 要求仕様
- [design.md](.epic/20260203-auth/design.md) - 技術設計
- [docs/SPEC_PR_GUIDE.md](docs/SPEC_PR_GUIDE.md) - 仕様PR作成ガイド