### PR TITLE
spec: Add data-testid naming convention and acceptance criteria for #112

### DIFF
--- a/specs/acceptance/data-testid/component-coverage.feature
+++ b/specs/acceptance/data-testid/component-coverage.feature
@@ -1,0 +1,104 @@
+# language: ja
+@data-testid @coverage @frontend
+Feature: data-testid コンポーネントカバレッジ
+
+  全フロントエンドコンポーネントに data-testid 属性が付与されていることを保証する。
+
+  Background:
+    Given フロントエンドアプリケーションが起動している
+
+  @positive @page
+  Scenario: ログインページの data-testid が存在する
+    Given ログインページにアクセスする
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid            |
+      | login-page             |
+      | login-username-input   |
+      | login-password-input   |
+      | login-submit-button    |
+
+  @positive @page
+  Scenario: メッセージ一覧ページの data-testid が存在する
+    Given 認証済みユーザーでメッセージ一覧ページにアクセスする
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid            |
+      | messages-page          |
+      | page-header            |
+      | message-table          |
+      | search-bar             |
+      | create-message-button  |
+      | pagination             |
+
+  @positive @component
+  Scenario: MessageTable コンポーネントの data-testid が存在する
+    Given メッセージが1件以上登録されている
+    And 認証済みユーザーでメッセージ一覧ページにアクセスする
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid            |
+      | message-table          |
+      | message-table-header   |
+    And message-row-{id} 形式の data-testid 要素がメッセージ件数分存在すること
+
+  @positive @component
+  Scenario: MessageForm コンポーネントの data-testid が存在する
+    Given 認証済みユーザーでメッセージ一覧ページにアクセスする
+    When 新規作成ボタンをクリックする
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid            |
+      | message-modal          |
+      | message-form           |
+      | message-code-input     |
+      | message-content-input  |
+      | message-form-submit    |
+      | message-form-cancel    |
+
+  @positive @component
+  Scenario: DeleteConfirmDialog コンポーネントの data-testid が存在する
+    Given メッセージが1件以上登録されている
+    And 認証済みユーザーでメッセージ一覧ページにアクセスする
+    When メッセージの削除ボタンをクリックする
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid              |
+      | delete-confirm-dialog    |
+      | delete-confirm-button    |
+      | delete-cancel-button     |
+
+  @positive @component
+  Scenario: SearchBar コンポーネントの data-testid が存在する
+    Given 認証済みユーザーでメッセージ一覧ページにアクセスする
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid        |
+      | search-bar         |
+      | search-input       |
+
+  @positive @component
+  Scenario: Pagination コンポーネントの data-testid が存在する
+    Given ページネーションが表示される件数のメッセージが登録されている
+    And 認証済みユーザーでメッセージ一覧ページにアクセスする
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid              |
+      | pagination               |
+      | pagination-prev-button   |
+      | pagination-next-button   |
+      | pagination-info          |
+
+  @positive @common
+  Scenario: 共通コンポーネントの data-testid が存在する
+    Given 認証済みユーザーでメッセージ一覧ページにアクセスする
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid    |
+      | page-header    |
+
+  @positive @common
+  Scenario: Loading コンポーネントの data-testid が存在する
+    Given データ読み込み中の状態である
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid      |
+      | loading-spinner  |
+
+  @positive @common
+  Scenario: ErrorMessage コンポーネントの data-testid が存在する
+    Given API エラーが発生した状態である
+    Then 以下の data-testid 要素が存在すること:
+      | data-testid    |
+      | error-message  |

--- a/specs/acceptance/data-testid/e2e-migration.feature
+++ b/specs/acceptance/data-testid/e2e-migration.feature
@@ -1,0 +1,76 @@
+# language: ja
+@data-testid @e2e @migration
+Feature: e2e テストの data-testid 移行
+
+  既存の e2e テストを data-testid ベースのセレクタに移行し、
+  テストの安定性と保守性を向上させる。
+
+  @positive @selector
+  Scenario: CSS クラスセレクタを data-testid に置換する
+    Given 以下の CSS クラスセレクタが e2e テストで使用されている:
+      | 現在のセレクタ              | 用途                  |
+      | .md\\:block table          | デスクトップテーブル表示  |
+      | .md\\:hidden               | モバイル表示            |
+    Then 以下の data-testid セレクタに置換されていること:
+      | 新しいセレクタ                                  | 用途                  |
+      | [data-testid="message-table-desktop"]          | デスクトップテーブル表示  |
+      | [data-testid="message-table-mobile"]           | モバイル表示            |
+
+  @positive @selector
+  Scenario: テキストベースセレクタを data-testid で補強する
+    Given 行の特定にテキストベースセレクタが使用されている:
+      | 現在のセレクタ                | 用途          |
+      | tr:has-text("{code}")        | メッセージ行特定 |
+    Then data-testid で行を特定できること:
+      | 新しいセレクタ                        | 用途          |
+      | [data-testid="message-row-{id}"]    | メッセージ行特定 |
+
+  @positive @selector
+  Scenario: ID/Name セレクタを data-testid に置換する
+    Given 以下の ID/Name セレクタが e2e テストで使用されている:
+      | 現在のセレクタ              | 用途              |
+      | input[id="username"]       | ユーザー名入力      |
+      | input[id="password"]       | パスワード入力      |
+      | input[name="code"]         | メッセージコード入力 |
+      | textarea[name="content"]   | メッセージ内容入力   |
+    Then 以下の data-testid セレクタに置換されていること:
+      | 新しいセレクタ                                    | 用途              |
+      | [data-testid="login-username-input"]             | ユーザー名入力      |
+      | [data-testid="login-password-input"]             | パスワード入力      |
+      | [data-testid="message-code-input"]               | メッセージコード入力 |
+      | [data-testid="message-content-input"]            | メッセージ内容入力   |
+
+  @positive @helper
+  Scenario: テストヘルパー関数が data-testid を使用する
+    Given tests/e2e/helpers.ts のヘルパー関数が更新されている
+    Then 以下のヘルパー関数が data-testid セレクタを使用すること:
+      | ヘルパー関数              | 使用する data-testid                  |
+      | login()                  | login-username-input, login-password-input, login-submit-button |
+      | waitForModal()           | message-modal                        |
+      | fillMessageForm()        | message-code-input, message-content-input |
+      | openCreateModal()        | create-message-button                |
+      | saveModalForm()          | message-form-submit                  |
+      | cancelModalForm()        | message-form-cancel                  |
+      | deleteMessage()          | delete-message-button-{id}, delete-confirm-button |
+      | performSearch()          | search-input                         |
+      | clearSearch()            | search-clear-button                  |
+
+  @positive @coexistence
+  Scenario: getByRole セレクタとの共存方針
+    Given アクセシビリティベースのセレクタ（getByRole）が使用されている
+    Then 以下の方針に従うこと:
+      | 方針                                              |
+      | getByRole は引き続き使用可能（アクセシビリティテスト目的） |
+      | 要素の特定が曖昧な場合は data-testid を優先する          |
+      | CSS クラスセレクタは data-testid に完全置換する          |
+      | テキストベースセレクタは data-testid で補強する          |
+
+  @positive @responsive
+  Scenario: レスポンシブテストで data-testid を使用する
+    Given レスポンシブデザインの e2e テストが存在する
+    Then 以下のビューポート切替テストが data-testid を使用すること:
+      | テスト内容              | 使用する data-testid          |
+      | デスクトップ表示確認     | message-table-desktop         |
+      | モバイル表示確認        | message-table-mobile          |
+      | テーブルヘッダー確認     | message-table-header          |
+      | メッセージ行確認        | message-row-{id}              |

--- a/specs/acceptance/data-testid/naming-convention.feature
+++ b/specs/acceptance/data-testid/naming-convention.feature
@@ -1,0 +1,85 @@
+# language: ja
+@data-testid @naming @frontend
+Feature: data-testid 命名規則
+
+  フロントエンドコンポーネントの data-testid 属性命名規則を定義し、
+  e2e テストの安定性と保守性を向上させる。
+
+  @convention
+  Scenario: 命名規則のフォーマット
+    Given data-testid の命名規則が定義されている
+    Then 以下のフォーマットに従うこと:
+      | ルール                     | 説明                                              |
+      | kebab-case                | 全て小文字のハイフン区切り                          |
+      | プレフィックスなし          | コンポーネント名をそのまま使用                       |
+      | 構造: {component}-{element} | コンポーネント名とサブ要素をハイフンで結合             |
+      | 動的ID: {component}-{id}   | 動的な要素にはユニークID（レコードIDなど）をサフィックスに付与 |
+
+  @convention
+  Scenario: ページレベルの data-testid
+    Given 各ページのルート要素に data-testid が付与されている
+    Then 以下の命名に従うこと:
+      | data-testid       | 対象コンポーネント |
+      | login-page        | ログインページ     |
+      | messages-page     | メッセージ一覧ページ |
+
+  @convention
+  Scenario: 共通コンポーネントの data-testid
+    Given 共通コンポーネントに data-testid が付与されている
+    Then 以下の命名に従うこと:
+      | data-testid       | 対象コンポーネント |
+      | page-header       | PageHeader        |
+      | loading-spinner   | Loading           |
+      | error-message     | ErrorMessage      |
+
+  @convention
+  Scenario: メッセージ機能コンポーネントの data-testid
+    Given メッセージ機能のコンポーネントに data-testid が付与されている
+    Then 以下の命名に従うこと:
+      | data-testid                       | 対象コンポーネント / 要素          |
+      | message-table                     | MessageTable ルート要素           |
+      | message-table-desktop             | デスクトップ表示のテーブル          |
+      | message-table-mobile              | モバイル表示のカード一覧           |
+      | message-table-header              | MessageTableHeader               |
+      | message-row-{id}                  | MessageTableRow（各行）           |
+      | message-form                      | MessageForm                      |
+      | message-modal                     | MessageModal                     |
+      | delete-confirm-dialog             | DeleteConfirmDialog              |
+      | search-bar                        | SearchBar                        |
+      | pagination                        | Pagination                       |
+
+  @convention
+  Scenario: フォーム要素の data-testid
+    Given フォーム要素に data-testid が付与されている
+    Then 以下の命名に従うこと:
+      | data-testid                | 対象要素                |
+      | login-username-input       | ログインユーザー名入力    |
+      | login-password-input       | ログインパスワード入力    |
+      | login-submit-button        | ログインボタン           |
+      | message-code-input         | メッセージコード入力      |
+      | message-content-input      | メッセージ内容入力        |
+      | message-form-submit        | メッセージ保存ボタン      |
+      | message-form-cancel        | メッセージキャンセルボタン |
+
+  @convention
+  Scenario: アクションボタンの data-testid
+    Given アクションボタンに data-testid が付与されている
+    Then 以下の命名に従うこと:
+      | data-testid                  | 対象要素                    |
+      | create-message-button        | 新規作成ボタン               |
+      | edit-message-button-{id}     | 編集ボタン（各行）           |
+      | delete-message-button-{id}   | 削除ボタン（各行）           |
+      | delete-confirm-button        | 削除確認ダイアログの確認ボタン |
+      | delete-cancel-button         | 削除確認ダイアログのキャンセルボタン |
+
+  @convention
+  Scenario: 検索・ページネーション要素の data-testid
+    Given 検索とページネーション要素に data-testid が付与されている
+    Then 以下の命名に従うこと:
+      | data-testid                | 対象要素          |
+      | search-input               | 検索テキスト入力    |
+      | search-clear-button        | 検索クリアボタン   |
+      | pagination-prev-button     | 前ページボタン     |
+      | pagination-next-button     | 次ページボタン     |
+      | pagination-page-{n}        | ページ番号ボタン   |
+      | pagination-info            | ページ情報テキスト  |


### PR DESCRIPTION
# 仕様PR

## 対象Story

Story: #112

## 変更内容

### OpenAPI仕様の変更

- [x] **変更なし** - 本Epicはフロントエンド専用の改善であり、API変更を伴わない

### 受け入れ条件ファイル

- [x] 新規 .feature ファイル作成

**ファイル：**

- `specs/acceptance/data-testid/naming-convention.feature` - data-testid 命名規則の定義
- `specs/acceptance/data-testid/component-coverage.feature` - 全コンポーネントのカバレッジ条件
- `specs/acceptance/data-testid/e2e-migration.feature` - 既存e2eテストの移行仕様

**シナリオ数：**

- 命名規則: 7シナリオ（ページ、共通、メッセージ、フォーム、アクション、検索、ページネーション）
- コンポーネントカバレッジ: 10シナリオ（正常系）
- e2eテスト移行: 6シナリオ（セレクタ置換、ヘルパー更新、共存方針、レスポンシブ）

## 仕様の完全性

- [x] すべてのコンポーネントに受け入れ条件が定義されている
- [x] 命名規則が明確に定義されている
- [x] 既存e2eテストの移行方針が定義されている
- [x] getByRole との共存方針が定義されている
- [x] Gherkin構文が正しい

## Breaking Changes

- [x] 破壊的変更なし

**詳細：**
data-testid 属性の追加はフロントエンドのみの変更であり、既存のAPIやバックエンドに影響はない。
既存のe2eテストは段階的に移行し、既存のセレクタも並行して動作する。

## 実装調査結果サマリー

### 現在の状況
- **e2eテストフレームワーク**: Playwright（6テストファイル）
- **data-testid使用状況**: 未使用（ゼロ）
- **現在のセレクタ戦略**: getByRole > getByPlaceholder > getByLabel > CSS > テキスト
- **対象コンポーネント**: UI(8) + Common(3) + Messages(8) + Pages(2) = 21コンポーネント

### 改善対象のセレクタ
| 現在のセレクタ | 問題点 | 改善後 |
|---|---|---|
| `.md\:block table` | CSS実装依存 | `[data-testid="message-table-desktop"]` |
| `.md\:hidden` | CSS実装依存 | `[data-testid="message-table-mobile"]` |
| `tr:has-text("{code}")` | テキスト変更で壊れる | `[data-testid="message-row-{id}"]` |
| `input[id="username"]` | ID依存 | `[data-testid="login-username-input"]` |

## レビュー観点

- [x] data-testid の命名規則が一貫しているか
- [x] 全コンポーネントがカバーされているか
- [x] 既存セレクタからの移行方針が明確か
- [x] getByRole との共存方針が適切か

## 備考

- 本Epicはフロントエンド専用の改善のため、OpenAPI仕様の変更はありません
- data-testid 命名規則は kebab-case を採用し、既存のファイル命名規則と整合性を保っています
- getByRole セレクタはアクセシビリティテスト目的で引き続き使用可能とし、CSS/テキストベースセレクタのみ置換対象としています