### PR TITLE
docs: Update SDD workflow to use Epic base branch for spec PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,21 +63,24 @@ docker compose -f docker-compose.yml up  # Production mode
 1. **Epic Issue 作成**（簡易版）
 2. 要求仕様の理解
 3. 現在の実装調査
-4. **仕様 PR 作成**（OpenAPI + 受け入れ条件）
-5. 仕様 PR レビュー・マージ
-6. **Issue に仕様を明記** + spec-approved ラベル付与
-7. **実装計画策定**（.epic/ 作成）
-8. 計画レビュー
-9. 実装/単体テスト実施
-10. 実装/単体テスト review 実施 & 指摘修正
-11. 結合テスト実施
-12. 結合テスト review 実施 & 指摘修正
-13. deploy 前確認
+4. **Epic ベースブランチ作成**（master から分岐）
+5. **仕様 PR 作成**（base: Epic branch, OpenAPI + 受け入れ条件）
+6. 仕様 PR レビュー・マージ（Epic branch へ）
+7. **Issue に仕様を明記** + spec-approved ラベル付与
+8. **実装計画策定**（.epic/ 作成）
+9. 計画レビュー
+10. 実装/単体テスト実施（Epic branch から Story 分岐）
+11. 実装/単体テスト review 実施 & 指摘修正
+12. Story PR マージ（Epic branch へ）
+13. 全 Story 完了後、Epic PR 作成（base: master）
+14. Epic PR レビュー・マージ
+15. deploy 前確認
 
 **重要**:
-- 仕様が確定してから実装計画を立てる（手戻りを防ぐ）
-- **仕様PRには実装を含まない**: ステップ4の仕様PRではOpenAPI仕様と受け入れ条件のみを追加し、実装コード（バックエンド・フロントエンド）は含めない。実装はステップ9以降で行う。
-- **実装計画策定時の注意**: ステップ7で実装計画を立てる際、仕様PRで追加されたAPIエンドポイントは未実装であることを前提とし、バックエンド実装とフロントエンド実装の両方をStoryに含める必要がある。
+
+- **仕様PRは Epic ブランチにマージ**: masterのビルドを保護するため、仕様PRはEpicベースブランチにマージします。OpenAPI仕様は既存Controllerに実装を強制するため、実装と一緒にmasterにマージする必要があります。
+- **仕様PRには空実装を含める**: ステップ5の仕様PRではOpenAPI仕様と受け入れ条件に加え、**空実装**（`throw new UnsupportedOperationException`）も含めます。これによりEpicブランチが常にビルド可能な状態を保ちます。実際の実装はステップ10以降で行います。
+- **Epic全体をまとめてmasterにマージ**: 全Story完了後、Epicブランチ全体をmasterにマージすることで、masterは常にビルド可能な状態を保ちます。
 
 ### カスタムスキルとの対応
 
@@ -86,20 +89,21 @@ SDDワークフローを効率化するため、各ステップに対応する�
 | ステップ | 内容 | スキル | 実行方法 | 備考 |
 |---------|------|---------|---------|------|
 | 1 | Epic Issue 作成 | `/create-epic-issue` | `/create-epic-issue [タイトル]` | GitHub に Epic Issue を作成 |
-| 2-4 | 要求理解+実装調査+仕様PR | `/create-spec-pr` | `/create-spec-pr [Issue番号]` | OpenAPI + 受け入れ条件を作成 |
-| 5 | 仕様 PR レビュー・マージ | - | 手動 | レビュアーによる承認 |
-| 6 | Issue更新 + spec-approved | `/update-spec-approved` | `/update-spec-approved [Issue番号] [PR番号]` | Issue に仕様を明記しラベル付与 |
-| 7 | 実装計画策定 + セルフレビュー | `/plan-epic` | `/plan-epic [Issue番号]` | .epic/ 作成と自動品質チェック |
-| 8 | 計画レビュー | - | 手動 | 人による最終確認 |
-| 9-12 | 実装/テスト | `/implement-epic` | `/implement-epic [Issue番号]` | Story実装と PR 作成 |
+| 2-5 | 要求理解+実装調査+仕様PR | `/create-spec-pr` | `/create-spec-pr [Issue番号]` | Epic branch 作成 + OpenAPI 仕様 PR |
+| 6 | 仕様 PR レビュー・マージ | - | 手動 | Epic branch へマージ |
+| 7 | Issue更新 + spec-approved | `/update-spec-approved` | `/update-spec-approved [Issue番号] [PR番号]` | Issue に仕様を明記しラベル付与 |
+| 8 | 実装計画策定 + セルフレビュー | `/plan-epic` | `/plan-epic [Issue番号]` | .epic/ 作成と自動品質チェック |
+| 9 | 計画レビュー | - | 手動 | 人による最終確認 |
+| 10-12 | 実装/テスト | `/implement-epic` | `/implement-epic [Issue番号]` | Story実装と PR 作成（Epic branch へ） |
+| 13-14 | Epic PR 作成・マージ | - | 手動 | Epic 全体を master へマージ |
 | - | Epic進捗確認 | `/epic-status` | `/epic-status [Issue番号]` | いつでも実行可能 |
-| 13 | deploy 前確認 | - | 手動 | 最終チェックリスト確認 |
+| 15 | deploy 前確認 | - | 手動 | 最終チェックリスト確認 |
 
 **スキルの特徴**:
 
-- `/create-spec-pr`: ステップ2（要求理解）、3（実装調査）、4（仕様PR作成）を一括実行
-- `/plan-epic`: ステップ7で計画を作成後、自動的にセルフレビューを実行
-- ステップ8（計画レビュー）は人が行うが、ステップ7の自動レビューで品質を担保
+- `/create-spec-pr`: ステップ2（要求理解）、3（実装調査）、4（Epic branch作成）、5（仕様PR作成）を一括実行
+- `/plan-epic`: ステップ8で計画を作成後、自動的にセルフレビューを実行
+- ステップ9（計画レビュー）は人が行うが、ステップ8の自動レビューで品質を担保
 
 **使用例**:
 
@@ -107,21 +111,24 @@ SDDワークフローを効率化するため、各ステップに対応する�
 # 1. Epic Issue作成
 /create-epic-issue 認証・認可機能
 
-# 2-4. 仕様PR作成（要求理解・実装調査・PR作成を自動実行）
+# 2-5. Epic branch作成 + 仕様PR作成（Epic branchへ）
 /create-spec-pr 88
 
-# 5. 仕様PRレビュー・マージ（手動）
+# 6. 仕様PRレビュー・マージ（手動、Epic branchへ）
 
-# 6. Issue更新
+# 7. Issue更新
 /update-spec-approved 88 102
 
-# 7. 実装計画策定（自動セルフレビュー含む）
+# 8. 実装計画策定（自動セルフレビュー含む）
 /plan-epic 88
 
-# 8. 計画レビュー（手動）
+# 9. 計画レビュー（手動）
 
-# 9-12. Epic実装
+# 10-12. Epic実装（各StoryはEpic branchへマージ）
 /implement-epic 88
+
+# 13-14. Epic PR作成・マージ（手動、masterへ）
+gh pr create --base master --head feature/issue-88-auth
 
 # 進捗確認（いつでも）
 /epic-status 88
@@ -189,8 +196,9 @@ Epic-based development uses the following branch strategy:
 
 ```
 master
-  └── feature/issue-[N]-[epic-name]
-       ├── feature/issue-[N]-[epic-name]-story1
+  └── feature/issue-[N]-[epic-name]  ← Epic base branch
+       ├── feature/issue-[N]-[epic-name]-spec     ← 仕様PR（OpenAPI + 受け入れ条件）
+       ├── feature/issue-[N]-[epic-name]-story1   ← Story実装
        └── ...
 ```
 

--- a/docs/development/GIT_WORKFLOW.md
+++ b/docs/development/GIT_WORKFLOW.md
@@ -8,8 +8,9 @@ Epic Documents に基づく開発では、以下のブランチ戦略を採用�
 
 ```
 master (main branch)
-  └── feature/issue-[N]-[epic-name]  ← epic のベースブランチ
-       ├── feature/issue-[N]-[epic-name]-story1
+  └── feature/issue-[N]-[epic-name]  ← Epic のベースブランチ
+       ├── feature/issue-[N]-[epic-name]-spec    ← 仕様PR (OpenAPI + 受け入れ条件)
+       ├── feature/issue-[N]-[epic-name]-story1  ← Story 実装
        ├── feature/issue-[N]-[epic-name]-story2
        ├── feature/issue-[N]-[epic-name]-story3
        └── ...
@@ -20,6 +21,7 @@ master (main branch)
 ```
 master
   └── feature/issue-88-auth
+       ├── feature/issue-88-auth-spec    (仕様定義: OpenAPI + 受け入れ条件)
        ├── feature/issue-88-auth-story1  (ユーザー管理基盤)
        ├── feature/issue-88-auth-story2  (JWT認証基盤)
        ├── feature/issue-88-auth-story3  (認証エンドポイント)
@@ -30,15 +32,41 @@ master
 
 ## ワークフロー
 
-### 1. Epic 開始時
+### 0. 仕様 PR 作成（Epic 開始前）
 
 ```bash
-# master から epic のベースブランチを作成
+# Epic ベースブランチを作成
 git checkout master
 git pull
 git checkout -b feature/issue-88-auth
 git push -u origin feature/issue-88-auth
+
+# 仕様ブランチを作成
+git checkout -b feature/issue-88-auth-spec
+
+# OpenAPI仕様と受け入れ条件を追加
+# ...編集作業...
+
+# 仕様PRを Epic ベースブランチに向けて作成
+gh pr create --base feature/issue-88-auth \
+             --head feature/issue-88-auth-spec \
+             --template .github/PULL_REQUEST_TEMPLATE/spec.md \
+             --label spec
+
+# レビュー・承認後、Epic ベースブランチにマージ
+gh pr merge --merge
+
+# Issue に spec-approved ラベル付与
+gh issue edit 88 --add-label spec-approved
 ```
+
+**重要**: 仕様PRは master ではなく **Epic ベースブランチ** にマージします。これにより、master のビルドを保護できます（OpenAPI 仕様は既存 Controller に実装を強制するため）。
+
+---
+
+### 1. Epic 開始時（仕様承認後）
+
+Epic ベースブランチは仕様PR作成時に既に作成済みです。
 
 ---
 
@@ -73,15 +101,15 @@ gh pr create --base feature/issue-88-auth \
 
 ---
 
-### 4. 全 Story 完了後（最終 PR）
+### 4. 全 Story 完了後（Epic PR: Epic branch → master）
 
 ```bash
-# epic ベースブランチ → master へ PR
+# Epic ベースブランチ → master へ PR
 gh pr create --base master \
              --head feature/issue-88-auth \
              --template .github/PULL_REQUEST_TEMPLATE/epic.md
 
-# PR タイトル例: "[Issue #88] 認証・認可機能の実装"
+# PR タイトル例: "[Epic #88] 認証・認可機能の実装"
 ```
 
 **PR 本文の必須項目:**
@@ -89,6 +117,15 @@ gh pr create --base master \
 - `Closes #[Issue番号]` （例: `Closes #88`）
 - 全 Story の完了確認
 - テスト実施結果
+- 仕様 PR への参照
+
+**この Epic PR には以下が含まれます:**
+
+- 仕様 (OpenAPI + 受け入れ条件)
+- 全 Story の実装
+- すべてのテストコード
+
+これにより、master は常にビルド可能な状態を保ちます。
 
 ---
 


### PR DESCRIPTION
## 概要

OpenAPI仕様PRを直接masterにマージすると、生成されるインターフェースが既存Controllerに実装を強制し、masterのビルドが壊れる問題を解決します。

## 問題

現在のSDDワークフローでは、仕様PRを直接masterにマージしています。しかし、OpenAPI仕様から生成されるインターフェース（例: `AuthApi.java`）は既存のControllerに新しいメソッドの実装を強制するため、実装がない状態でmasterがビルドエラーになります。

## 解決策

### 1. 仕様PRをEpic baseブランチにマージ

- 仕様PRのマージ先をmasterからEpic baseブランチに変更
- Epic全体（仕様+全Story実装）をまとめてmasterにマージ
- masterは常にビルド可能な状態を保つ

### 2. 空実装の導入

仕様PRにOpenAPI仕様と受け入れ条件に加え、**空実装**を含めます：

```java
@Override
public ResponseEntity<UserResponse> getCurrentUser() {
  throw new UnsupportedOperationException("Not implemented yet - Story 3");
}
```

これにより：
- Epic branchが常にビルド可能
- CIが正しく機能
- Story実装者が何を実装すべきか明確

## 変更内容

### CLAUDE.md
- SDDワークフローステップを15ステップに更新
- Epic baseブランチ作成を明記
- 空実装の重要性を追記
- カスタムスキル対応表を更新

### docs/development/SPEC_PR_GUIDE.md
- 新セクション「3. 空実装の追加（ビルドエラー回避）」を追加
- 作成手順を7ステップに更新（空実装追加とビルド確認を追加）
- 「Epic ベースブランチへのマージの利点」セクションを追加
- チェックリストに空実装とビルド確認を追加

### docs/development/GIT_WORKFLOW.md
- ブランチ構成図に仕様ブランチを追加
- 新セクション「0. 仕様 PR 作成」を追加
- Epic PR の内容を明記

## メリット

✅ **masterのビルド保護**: masterは常にビルド可能  
✅ **CIの正常動作**: Epic branchでもCIが緑  
✅ **実装の明確化**: 空実装が何を実装すべきか示す  
✅ **仕様承認プロセスの維持**: GitHubのPR Approveで正式に承認  

## 関連Issue

Epic #140 のビルド失敗の根本原因に対処するため、SDDワークフローを改善。

🤖 Generated with [Claude Code](https://claude.com/claude-code)