### PR TITLE
[Spec] 多言語（日本語・英語）対応 #155

### DIFF
--- a/specs/acceptance/i18n/language-switch.feature
+++ b/specs/acceptance/i18n/language-switch.feature
@@ -1,0 +1,88 @@
+# language: ja
+@i18n @language-switch @ui
+Feature: 言語切り替え機能
+
+  ユーザーが日本語と英語の間でUIの表示言語を切り替えられる機能。
+  言語切り替えボタンはすべての画面（ログイン画面・メイン画面）で利用可能。
+
+  Background:
+    Given アプリケーションが起動している
+
+  @positive
+  Scenario: ログイン画面に言語切り替えボタンが表示される
+    When ログイン画面 (/login) を開く
+    Then 言語切り替えボタン（日/EN）が表示される
+
+  @positive
+  Scenario: メイン画面に言語切り替えボタンが表示される
+    Given 管理者ユーザーでログイン済みである
+    When メイン画面 (/) を開く
+    Then 言語切り替えボタン（日/EN）が表示される
+
+  @positive
+  Scenario: 日本語選択時にログイン画面のUIテキストが日本語で表示される
+    Given ログイン画面 (/login) を開く
+    When 言語切り替えボタンで「日本語」を選択する
+    Then ページタイトルが「ログイン」と表示される
+    And ユーザー名ラベルが「ユーザー名」と表示される
+    And パスワードラベルが「パスワード」と表示される
+    And ログインボタンが「ログイン」と表示される
+
+  @positive
+  Scenario: 英語選択時にログイン画面のUIテキストが英語で表示される
+    Given ログイン画面 (/login) を開く
+    When 言語切り替えボタンで「English」を選択する
+    Then ページタイトルが「Login」と表示される
+    And ユーザー名ラベルが「Username」と表示される
+    And パスワードラベルが「Password」と表示される
+    And ログインボタンが「Login」と表示される
+
+  @positive
+  Scenario: 英語選択時にメイン画面のUIテキストが英語で表示される
+    Given 管理者ユーザーでログイン済みである
+    And メイン画面 (/) を開いている
+    When 言語切り替えボタンで「English」を選択する
+    Then ページタイトルが「Message Management」と表示される
+    And ページ説明が「Manage all your messages in one place」と表示される
+    And 新規作成ボタンが「New Message」と表示される
+    And ログアウトボタンが「Logout」と表示される
+
+  @positive
+  Scenario: 日本語選択時にメイン画面のUIテキストが日本語で表示される
+    Given 管理者ユーザーでログイン済みである
+    And メイン画面 (/) を開いている
+    When 言語切り替えボタンで「日本語」を選択する
+    Then ページタイトルが「メッセージ管理」と表示される
+    And ページ説明が「すべてのメッセージを一元管理します」と表示される
+    And 新規作成ボタンが「新規作成」と表示される
+    And ログアウトボタンが「ログアウト」と表示される
+
+  @positive
+  Scenario: テーブルヘッダーが選択言語で表示される
+    Given 管理者ユーザーでログイン済みである
+    And メイン画面 (/) を開いている
+    When 言語切り替えボタンで「English」を選択する
+    Then テーブルヘッダーが以下のように表示される:
+      | 列     | 英語テキスト |
+      | ID     | ID           |
+      | Code   | Code         |
+      | Content | Content     |
+      | Actions | Actions     |
+
+  @positive
+  Scenario: ダイアログのテキストが選択言語で表示される
+    Given 管理者ユーザーでログイン済みである
+    And メイン画面 (/) を開いている
+    And 言語切り替えボタンで「English」を選択している
+    When 「New Message」ボタンをクリックして作成モーダルを開く
+    Then モーダルタイトルが「Create Message」と表示される
+    And 保存ボタンが「Save」と表示される
+    And キャンセルボタンが「Cancel」と表示される
+
+  @positive
+  Scenario: ログインエラーメッセージが選択言語で表示される
+    Given ログイン画面 (/login) を開く
+    And 言語切り替えボタンで「English」を選択している
+    When 誤ったパスワードでログインを試みる
+    Then エラーメッセージが英語で表示される
+    And エラーメッセージに「Login failed」が含まれる

--- a/specs/acceptance/i18n/locale-persistence.feature
+++ b/specs/acceptance/i18n/locale-persistence.feature
@@ -1,0 +1,58 @@
+# language: ja
+@i18n @locale-persistence @ui
+Feature: 言語設定の永続化
+
+  ユーザーが選択した言語設定がページリロードやセッションをまたいで保持される機能。
+  言語設定は localStorage に保存し、次回アクセス時に自動的に適用される。
+
+  Background:
+    Given アプリケーションが起動している
+
+  @positive
+  Scenario: 英語選択後にページをリロードしても英語が維持される
+    Given ログイン画面 (/login) を開く
+    And 言語切り替えボタンで「English」を選択している
+    When ページをリロードする
+    Then 言語設定が「English」のままである
+    And ページタイトルが「Login」と表示される
+
+  @positive
+  Scenario: 日本語選択後にページをリロードしても日本語が維持される
+    Given ログイン画面 (/login) を開く
+    And 言語切り替えボタンで「English」を選択している
+    When 言語切り替えボタンで「日本語」を選択する
+    And ページをリロードする
+    Then 言語設定が「日本語」のままである
+    And ページタイトルが「ログイン」と表示される
+
+  @positive
+  Scenario: ログイン後も選択言語が引き継がれる
+    Given ログイン画面 (/login) を開く
+    And 言語切り替えボタンで「English」を選択している
+    When 正しい認証情報でログインする
+    Then メイン画面にリダイレクトされる
+    And 言語設定が「English」のままである
+    And ページタイトルが「Message Management」と表示される
+
+  @positive
+  Scenario: ログアウト後も選択言語が引き継がれる
+    Given 管理者ユーザーでログイン済みである
+    And メイン画面 (/) を開いている
+    And 言語切り替えボタンで「English」を選択している
+    When ログアウトボタンをクリックしてログアウトする
+    Then ログイン画面にリダイレクトされる
+    And 言語設定が「English」のままである
+    And ページタイトルが「Login」と表示される
+
+  @positive
+  Scenario: 初回アクセス時のデフォルト言語は日本語である
+    Given ブラウザのローカルストレージに言語設定が存在しない
+    When ログイン画面 (/login) を開く
+    Then 言語設定が「日本語」である
+    And ページタイトルが「ログイン」と表示される
+
+  @positive
+  Scenario: 言語設定がlocalStorageに保存される
+    Given ログイン画面 (/login) を開く
+    When 言語切り替えボタンで「English」を選択する
+    Then localStorage のキー「locale」の値が「en」である


### PR DESCRIPTION
Story: #155

## 変更概要

Issue #155「多言語（日本語、英語）への対応」の仕様PRです。

## 要求仕様の理解（Step 2）

**背景**: 現在は日本語のみ対応しており、英語ユーザーが利用できない状態

**目的**: 日英切り替えUIの実現、ユーザーが母語でサービスを利用できる環境構築

**スコープ（Phase 1）**:
- 日英切り替え機能の実装
- UIテキストの翻訳対応（日本語・英語）

## 実装調査結果（Step 3）

**現状の確認**:
- `layout.tsx`: `lang="ja"` がハードコード
- ログインページ: 日本語テキストがハードコード（ログイン、ユーザー名 等）
- メインページ: 英語テキストがハードコード（Message Management, Logout 等）
- i18nライブラリ: 未導入（next-intl, react-i18next 等なし）

**影響範囲**:
- OpenAPI仕様変更: **なし**（Phase 1はフロントエンドのみ）
- 言語設定の保存: localStorage（サーバーサイドAPI不要）
- Breaking Changes: なし

**技術方針**:
- i18nライブラリの導入（next-intl 推奨: Next.js App Router対応）
- 言語切り替えボタンのUIコンポーネント追加
- 翻訳ファイル（ja.json / en.json）の作成

## 作成した仕様（Step 4）

### 受け入れ条件

#### specs/acceptance/i18n/language-switch.feature（8シナリオ）
- 言語切り替えボタンの表示（ログイン・メイン画面）
- 日/英選択時のUIテキスト変更（ログインページ）
- 日/英選択時のUIテキスト変更（メインページ）
- テーブルヘッダーの言語対応
- ダイアログテキストの言語対応
- ログインエラーメッセージの言語対応

#### specs/acceptance/i18n/locale-persistence.feature（6シナリオ）
- ページリロード後も言語設定が維持される
- ログイン/ログアウト後も言語設定が引き継がれる
- 初回アクセス時のデフォルト言語は日本語
- localStorageのキー「locale」に設定が保存される

### OpenAPI変更

なし（Phase 1はフロントエンドのみの変更）

## 変更ファイル

- `specs/acceptance/i18n/language-switch.feature` (新規)
- `specs/acceptance/i18n/locale-persistence.feature` (新規)

🤖 Generated with [Claude Code](https://claude.com/claude-code)