### PR TITLE
Story 2: 言語切り替えコンポーネントと画面組み込み (#155)

### DIFF
--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import LoginPage from './page';
 import * as useAuthModule from '@/hooks/useAuth';
+import { LocaleProvider } from '@/contexts/LocaleContext';
 import type { ReactNode } from 'react';
 
 // Mock useRouter
@@ -26,7 +27,9 @@ const createWrapper = () => {
   });
 
   const Wrapper = ({ children }: { children: ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <LocaleProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </LocaleProvider>
   );
   Wrapper.displayName = 'TestWrapper';
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { LanguageSwitcher } from '@/components/common/LanguageSwitcher';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function LoginPage() {
@@ -32,6 +33,9 @@ export default function LoginPage() {
       data-testid="login-page"
       className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12"
     >
+      <div className="absolute top-4 right-4">
+        <LanguageSwitcher />
+      </div>
       <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
         <div className="mb-6 text-center">
           <h1 className="text-2xl font-bold">ログイン</h1>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,6 +5,7 @@ import { PageHeader } from '@/components/common/PageHeader';
 import MessageTable from '@/components/messages/MessageTable';
 import MessageModal from '@/components/messages/MessageModal';
 import DeleteConfirmDialog from '@/components/messages/DeleteConfirmDialog';
+import { LanguageSwitcher } from '@/components/common/LanguageSwitcher';
 import { RoleBasedComponent } from '@/components/common/RoleBasedComponent';
 import { Button } from '@/components/ui/button';
 import { Plus, LogOut } from 'lucide-react';
@@ -145,10 +146,13 @@ export default function Home() {
             </RoleBasedComponent>
           }
           rightContent={
-            <Button variant="outline" onClick={handleLogout}>
-              <LogOut className="h-4 w-4 mr-2" />
-              Logout
-            </Button>
+            <div className="flex items-center gap-2">
+              <LanguageSwitcher />
+              <Button variant="outline" onClick={handleLogout}>
+                <LogOut className="h-4 w-4 mr-2" />
+                Logout
+              </Button>
+            </div>
           }
         />
         <MessageTable onEdit={handleEditClick} onDelete={handleDeleteClick} />

--- a/frontend/src/components/common/LanguageSwitcher.stories.tsx
+++ b/frontend/src/components/common/LanguageSwitcher.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { LocaleContext } from '@/contexts/LocaleContext';
+import enMessages from '../../../messages/en.json';
+import jaMessages from '../../../messages/ja.json';
+import { LanguageSwitcher } from './LanguageSwitcher';
+
+const meta = {
+  title: 'Common/LanguageSwitcher',
+  component: LanguageSwitcher,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof LanguageSwitcher>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * 日本語設定時（ボタンラベルが「EN」）
+ */
+export const Default: Story = {
+  args: {},
+  render: (_args) => (
+    <LocaleContext.Provider
+      value={{
+        locale: 'ja',
+        setLocale: () => {},
+        messages: jaMessages as Record<string, unknown>,
+      }}
+    >
+      <LanguageSwitcher />
+    </LocaleContext.Provider>
+  ),
+};
+
+/**
+ * 英語設定時（ボタンラベルが「日」）
+ */
+export const English: Story = {
+  args: {},
+  render: (_args) => (
+    <LocaleContext.Provider
+      value={{
+        locale: 'en',
+        setLocale: () => {},
+        messages: enMessages as Record<string, unknown>,
+      }}
+    >
+      <LanguageSwitcher />
+    </LocaleContext.Provider>
+  ),
+};

--- a/frontend/src/components/common/LanguageSwitcher.tsx
+++ b/frontend/src/components/common/LanguageSwitcher.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useLocale } from '@/contexts/LocaleContext';
+import { cn } from '@/lib/utils';
+
+export interface LanguageSwitcherProps {
+  className?: string;
+}
+
+export function LanguageSwitcher({ className }: LanguageSwitcherProps) {
+  const { locale, setLocale } = useLocale();
+
+  const handleClick = () => {
+    setLocale(locale === 'ja' ? 'en' : 'ja');
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      data-testid="language-switcher"
+      className={cn(className)}
+      aria-label={locale === 'ja' ? 'Switch to English' : '日本語に切り替え'}
+    >
+      {locale === 'ja' ? 'EN' : '日'}
+    </Button>
+  );
+}

--- a/frontend/tests/component/LanguageSwitcher.test.tsx
+++ b/frontend/tests/component/LanguageSwitcher.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { LanguageSwitcher } from '@/components/common/LanguageSwitcher';
+import { LocaleContext } from '@/contexts/LocaleContext';
+import jaMessages from '../../messages/ja.json';
+import enMessages from '../../messages/en.json';
+import type { ReactNode } from 'react';
+
+function createJaWrapper() {
+  function JaWrapper({ children }: { children: ReactNode }) {
+    return (
+      <LocaleContext.Provider
+        value={{
+          locale: 'ja',
+          setLocale: vi.fn(),
+          messages: jaMessages as Record<string, unknown>,
+        }}
+      >
+        {children}
+      </LocaleContext.Provider>
+    );
+  }
+  return JaWrapper;
+}
+
+function createEnWrapper(setLocale = vi.fn()) {
+  function EnWrapper({ children }: { children: ReactNode }) {
+    return (
+      <LocaleContext.Provider
+        value={{
+          locale: 'en',
+          setLocale,
+          messages: enMessages as Record<string, unknown>,
+        }}
+      >
+        {children}
+      </LocaleContext.Provider>
+    );
+  }
+  return EnWrapper;
+}
+
+describe('LanguageSwitcher', () => {
+  describe('表示', () => {
+    it('日本語設定時に「EN」が表示される', () => {
+      render(<LanguageSwitcher />, { wrapper: createJaWrapper() });
+      expect(screen.getByTestId('language-switcher')).toBeInTheDocument();
+      expect(screen.getByText('EN')).toBeInTheDocument();
+    });
+
+    it('英語設定時に「日」が表示される', () => {
+      render(<LanguageSwitcher />, { wrapper: createEnWrapper() });
+      expect(screen.getByTestId('language-switcher')).toBeInTheDocument();
+      expect(screen.getByText('日')).toBeInTheDocument();
+    });
+
+    it('data-testid="language-switcher" で要素を取得できる', () => {
+      render(<LanguageSwitcher />, { wrapper: createJaWrapper() });
+      const button = screen.getByTestId('language-switcher');
+      expect(button).toBeVisible();
+    });
+  });
+
+  describe('クリック操作', () => {
+    it('日本語設定時にクリックすると setLocale("en") が呼ばれる', async () => {
+      const setLocale = vi.fn();
+      const user = userEvent.setup();
+
+      const Wrapper = ({ children }: { children: ReactNode }) => (
+        <LocaleContext.Provider
+          value={{
+            locale: 'ja',
+            setLocale,
+            messages: jaMessages as Record<string, unknown>,
+          }}
+        >
+          {children}
+        </LocaleContext.Provider>
+      );
+
+      render(<LanguageSwitcher />, { wrapper: Wrapper });
+
+      await user.click(screen.getByTestId('language-switcher'));
+
+      expect(setLocale).toHaveBeenCalledOnce();
+      expect(setLocale).toHaveBeenCalledWith('en');
+    });
+
+    it('英語設定時にクリックすると setLocale("ja") が呼ばれる', async () => {
+      const setLocale = vi.fn();
+      const user = userEvent.setup();
+
+      render(<LanguageSwitcher />, { wrapper: createEnWrapper(setLocale) });
+
+      await user.click(screen.getByTestId('language-switcher'));
+
+      expect(setLocale).toHaveBeenCalledOnce();
+      expect(setLocale).toHaveBeenCalledWith('ja');
+    });
+  });
+
+  describe('className prop', () => {
+    it('className が渡された場合にクラスが適用される', () => {
+      render(<LanguageSwitcher className="custom-class" />, { wrapper: createJaWrapper() });
+      const button = screen.getByTestId('language-switcher');
+      expect(button).toHaveClass('custom-class');
+    });
+  });
+});


### PR DESCRIPTION
Story: #155

## Story 概要
Story 2: 言語切り替えコンポーネントと画面組み込み

## 変更内容
- `LanguageSwitcher` コンポーネントを実装（named export、`data-testid="language-switcher"`）
- Storybook ストーリーを作成（日本語時・英語時の2ストーリー）
- コンポーネントテストを作成（6テスト: 表示・クリック操作・className）
- ログインページ（`src/app/login/page.tsx`）の右上に `LanguageSwitcher` を追加
- メインページのヘッダー（`src/app/page.tsx`）のログアウトボタン隣に `LanguageSwitcher` を追加
- ログインページのテスト（`src/app/login/page.test.tsx`）に `LocaleProvider` ラッパーを追加

## このPRで検証した受け入れ条件
- [x] `LanguageSwitcher` ボタンがログインページに表示される（`data-testid="language-switcher"`）
- [x] `LanguageSwitcher` ボタンがメインページに表示される（`data-testid="language-switcher"`）
- [x] クリックで日本語⇔英語が切り替わる（ボタンラベルが「EN」⇔「日」で変わる）
- [x] Storybook ストーリーが作成されている
- [x] コンポーネントテストが作成されている
- [x] `pnpm test` と `pnpm type-check` が通過する

## テスト
- [x] 単体テスト（`pnpm test --run` 275テスト全通過）
- [x] 型チェック（`pnpm type-check` 通過）
- [x] ビルド確認（`pnpm build` 通過）

## 備考
- `login/page.test.tsx` に `LocaleProvider` ラッパーを追加（`LanguageSwitcher` が `useLocale()` を必要とするため）
- ESLint `react/display-name` ルールに対応するため、テスト内の無名関数コンポーネントを named function に変更