### PR TITLE
spec: Login i18n E2E テストを Component テストに移行する #174

### DIFF
--- a/specs/acceptance/login-i18n-component-test/login-error-i18n.feature
+++ b/specs/acceptance/login-i18n-component-test/login-error-i18n.feature
@@ -1,0 +1,34 @@
+# language: ja
+@frontend @component @i18n @login
+Feature: ログインエラーメッセージの i18n Component テスト
+
+  LoginPage で英語ロケール設定時にエラーメッセージが英語で表示されることを
+  Component テストで検証する。
+  E2E テスト禁止パターン（i18n テキスト表示検証）を Component テストに移行する。
+
+  Background:
+    Given `useAuth` フックがモックされている
+    And `useRouter` がモックされている
+
+  @positive
+  Scenario: 英語設定時にログイン失敗エラーメッセージが英語で表示される
+    Given LoginPage が英語ロケール（`createLocaleWrapper('en')`）でレンダリングされている
+    And `login` モック関数が失敗（reject）するよう設定されている
+    When ユーザー名とパスワードを入力してログインボタンをクリックする
+    Then `[role="alert"]` にエラーメッセージが表示される
+    And エラーメッセージのテキストが英語である（"Login failed" を含む）
+
+  @positive
+  Scenario: 日本語設定時にログイン失敗エラーメッセージが日本語で表示される
+    Given LoginPage が日本語ロケール（`createLocaleWrapper('ja')`）でレンダリングされている
+    And `login` モック関数が失敗（reject）するよう設定されている
+    When ユーザー名とパスワードを入力してログインボタンをクリックする
+    Then `[role="alert"]` にエラーメッセージが表示される
+    And エラーメッセージのテキストが日本語である（"ログインに失敗しました" を含む）
+
+  @negative
+  Scenario: E2E テストから i18n テキスト検証を削除する
+    Given `language-switch.spec.ts` に "ログインエラーメッセージが英語で表示される" テストが存在する
+    Then そのテストは `language-switch.spec.ts` から削除されている
+    And 代わりに LoginPage Component テストで検証されている
+    And E2E テスト総数が削減されている（20件 → 19件以下）


### PR DESCRIPTION
# 仕様PR

## 対象Story

Story: #174

## 変更内容

### OpenAPI仕様の変更

変更なし（テストリファクタリングのみ）

### 受け入れ条件ファイル

- [x] 新規 .feature ファイル作成

**ファイル：**

- `specs/acceptance/login-i18n-component-test/login-error-i18n.feature`

**シナリオ数：**

- 正常系: 2件（英語・日本語ロケールでのエラーメッセージ表示）
- 異常系: 1件（E2E テスト削除の確認）

## 仕様の完全性

- [x] すべての変更に受け入れ条件が定義されている
- [x] 正常系と異常系の両方がカバーされている
- [x] Gherkin 構文が正しい
- [x] OpenAPI 変更なし（テストのみ）

## Breaking Changes

- [x] 破壊的変更なし

## ティア判定

**判定結果**: Micro

**判定根拠**:
- API スキーマ変更: 非該当 - OpenAPI 変更なし
- DB スキーマ変更: 非該当
- 既存機能の変更: 非該当 - テストコード（`tests/`）のみの変更
- **docs・tests のみの変更: 該当** ✅

**計画承認後の実装方式**:
- Micro の場合: 単一 feature ブランチ → Epic PR のみ（自律実装）

> レビュー時にティアを承認してください。変更がある場合はコメントで指示をお願いします。
> 承認後 `/update-spec-approved` 実行時にティアを伝えてください。

## 要求仕様の理解

**背景**: `language-switch.spec.ts` の「ログインエラーメッセージが英語で表示される」テストが
E2E テスト禁止パターン（i18n テキスト表示検証）に該当（`frontend/docs/BEST_PRACTICES.md §4` 違反）。

**目的**:
- `LocaleContext` をモックした Component テストで i18n エラーメッセージを検証
- 不要な E2E テストを削除し E2E テスト総数を削減（20件 → 19件以下）

## 実装調査結果

**既存の関連機能**:
- `frontend/src/app/login/page.tsx`: `useTranslations('login')` で `t('error')` を使用
- `frontend/src/app/login/page.test.tsx`: 日本語ロケールのテストのみ存在
- `tests/unit/helpers/localeTestHelper.tsx`: `createLocaleWrapper('en')` が利用可能
- `frontend/messages/en.json`: `"error": "Login failed. Username or password is incorrect."`

**影響範囲**:
- テストコードのみ（`tests/` ディレクトリ）
- Breaking Changes: なし