### PR TITLE
test: language-switch.spec.ts の E2E テストを Component テストに移行する (#174)

### DIFF
--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -18,7 +18,7 @@ vi.mock('next/navigation', () => ({
 // Mock useAuth
 vi.mock('@/hooks/useAuth');
 
-const createWrapper = () => {
+const createWrapper = (locale: 'ja' | 'en' = 'ja') => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -26,14 +26,14 @@ const createWrapper = () => {
     },
   });
 
-  const LocaleWrapper = createLocaleWrapper('ja');
+  const LocaleWrapper = createLocaleWrapper(locale);
 
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <LocaleWrapper>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </LocaleWrapper>
   );
-  Wrapper.displayName = 'TestWrapper';
+  Wrapper.displayName = `TestWrapper(${locale})`;
 
   return Wrapper;
 };
@@ -151,6 +151,36 @@ describe('LoginPage', () => {
         expect(
           screen.getByText('ログインに失敗しました。ユーザー名またはパスワードが正しくありません。')
         ).toBeInTheDocument();
+      });
+    });
+
+    it('英語設定時にログイン失敗エラーメッセージが英語で表示される', async () => {
+      const user = userEvent.setup();
+      mockLogin.mockRejectedValue(new Error('Unauthorized'));
+
+      render(<LoginPage />, { wrapper: createWrapper('en') });
+
+      await user.type(screen.getByTestId('login-username-input'), 'admin');
+      await user.type(screen.getByTestId('login-password-input'), 'wrongpassword');
+      await user.click(screen.getByTestId('login-submit-button'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Login failed');
+      });
+    });
+
+    it('日本語設定時にログイン失敗エラーメッセージが日本語で表示される', async () => {
+      const user = userEvent.setup();
+      mockLogin.mockRejectedValue(new Error('Unauthorized'));
+
+      render(<LoginPage />, { wrapper: createWrapper() });
+
+      await user.type(screen.getByTestId('login-username-input'), 'admin');
+      await user.type(screen.getByTestId('login-password-input'), 'wrongpassword');
+      await user.click(screen.getByTestId('login-submit-button'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('ログインに失敗しました');
       });
     });
 

--- a/frontend/tests/e2e/language-switch.spec.ts
+++ b/frontend/tests/e2e/language-switch.spec.ts
@@ -32,21 +32,6 @@ test.describe('言語切り替え機能', () => {
     await expect(page.getByTestId('language-switcher')).toBeVisible({ timeout: 10000 });
   });
 
-  test('ログインエラーメッセージが英語で表示される', async ({ page }) => {
-    await switchToEnglish(page);
-
-    // Fill in invalid credentials
-    await page.getByTestId('login-username-input').fill('wronguser');
-    await page.getByTestId('login-password-input').fill('wrongpassword');
-    await page.getByTestId('login-submit-button').click();
-
-    // Error message should appear in English
-    // Use form [role="alert"] to avoid matching Next.js route announcer (#__next-route-announcer__)
-    const errorAlert = page.locator('form [role="alert"]');
-    await expect(errorAlert).toBeVisible({ timeout: 10000 });
-    await expect(errorAlert).toContainText('Login failed');
-  });
-
   test('ログイン後も選択言語が引き継がれる', async ({ page }) => {
     // Select English on login page
     await switchToEnglish(page);


### PR DESCRIPTION
Closes #174

## 概要

`language-switch.spec.ts` の i18n テキスト検証 E2E テスト（禁止パターン）を `LoginPage` の Component テストに移行する。

**ティア**: Micro（tests のみ変更）

## 変更内容

- `LoginPage` Component テストに英語・日本語ロケールのエラーメッセージ検証テスト 2件追加
- `createWrapper()` にロケールパラメータ（`'ja' | 'en'`）を追加し、重複コードを排除
- `language-switch.spec.ts` から i18n テキスト検証 E2E テスト 1件を削除

## 完了した Story

- [x] Story 1: E2E テストを Component テストに移行

## テスト

- [x] すべての単体テストが通過（`pnpm test`: 279件）
- [x] `pnpm lint` + `pnpm type-check` が通過
- [x] E2E テストが通過（19件、削除前 20件）

## デプロイ前チェックリスト

（変更なし。tests のみ）